### PR TITLE
fix: remove hard-coded paths and patch overrides

### DIFF
--- a/rash/examples/linting_demo.rs
+++ b/rash/examples/linting_demo.rs
@@ -202,8 +202,6 @@ const SIMULATION_TESTS: &[(&str, &str, &str)] = &[
 
 fn find_bashrs_binary() -> Option<&'static str> {
     let candidates = [
-        "/mnt/nvme-raid0/targets/bashrs/release/bashrs",
-        "/mnt/nvme-raid0/targets/bashrs/debug/bashrs",
         "target/release/bashrs",
         "target/debug/bashrs",
     ];

--- a/rash/src/validation/pipeline.rs
+++ b/rash/src/validation/pipeline.rs
@@ -781,7 +781,7 @@ mod tests {
         let pipeline = create_test_pipeline();
         // Complex shell commands should work in exec()
         let result = pipeline.validate_string_literal_in_exec(
-            "ldd /home/noah/.local/bin/main 2>/dev/null | grep -i blas | head -1",
+            "ldd /usr/local/bin/main 2>/dev/null | grep -i blas | head -1",
         );
         assert!(
             result.is_ok(),


### PR DESCRIPTION
## Summary

- Remove `/mnt/nvme-raid0` hard-coded binary candidate paths from `rash/examples/linting_demo.rs` — only portable `target/release/bashrs` and `target/debug/bashrs` relative paths are kept
- Replace `/home/noah/.local/bin/main` test fixture path in `rash/src/validation/pipeline.rs` with `/usr/local/bin/main` (a generic system path that works in any environment)
- No `[patch.crates-io]` entries with `path =` were found in any Cargo.toml files (already clean)

These absolute paths break clean-room CI builds where neither `/mnt/nvme-raid0` nor `/home/noah` exist.

## Test plan

- [x] `cargo check` passes cleanly after changes
- [x] No remaining `/mnt/nvme-raid0` or `/home/noah` references in any `.rs` files
- [x] Validation test `test_issue_95_complex_exec_command` still exercises the same behavior (complex exec pipeline validation) with a portable path

Spec: sovereign-stack-protected-branch-strategy.md (Section 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)