### PR TITLE
ci: enable sccache pilot (medium workload) — Phase 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # Phase 3 pilot (medium workload) — build-performance.md §7 Phase 3.
+      # Workspace with rash + runtime + wasm — moderate dep graph,
+      # candidate for mid-range hit-rate signal between copia and pmat.
+      enable_sccache: true
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,21 @@ jobs:
       repo: ${{ github.event.repository.name }}
       # Phase 3 pilot (medium workload) — build-performance.md §7 Phase 3.
       # Workspace with rash + runtime + wasm — moderate dep graph,
-      # candidate for mid-range hit-rate signal between copia and pmat.
+      # candidate for mid-range hit-rate signal between copia and aprender.
       enable_sccache: true
     secrets: inherit
 
+  # Top-level gate: org ruleset requires status check named "gate" (exact match).
+  # The reusable workflow produces "ci / gate" which doesn't satisfy the ruleset.
+  gate:
+    runs-on: ubuntu-latest
+    needs: [ci]
+    if: always()
+    steps:
+      - name: Check required jobs
+        run: |
+          if [ "${{ needs.ci.result }}" != "success" ]; then
+            echo "ci failed: ${{ needs.ci.result }}"
+            exit 1
+          fi
+          echo "All required jobs passed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",


### PR DESCRIPTION
## Summary

Opts bashrs into the sovereign-ci.yml `enable_sccache` input introduced in paiml/.github#21. Per **build-performance.md §7 Phase 3**, bashrs is the **medium-workload** pilot — workspace with rash + rash-runtime + bashrs-wasm sits between copia (light) and pmat (heavy) for comparing cache-hit-rate signal.

The reusable workflow already provides everything needed:
- `RUSTC_WRAPPER=sccache` / `SCCACHE_DIR=/sccache` env
- `/home/noah/data/sccache` bind-mount into CI container (forjar-managed)
- `sccache --show-stats --stats-format json` emitted to `/var/log/ci-metrics/sccache-<run>-<repo>-<job>.json`
- F9 falsify example (`infra/examples/falsify_f9_cache_hit_rate.rs`) consumes those files over a 7-day window (threshold: p95 hit-rate ≥ 40%)

**Opt-out**: remove `enable_sccache: true` — default remains `false` for all other repos.

Includes a `cc 1.2.59 -> 1.2.60` Cargo.lock bump — 1.2.59 breaks on the local rustc 1.93 apple-sdk API (clean-room uses 1.95).

## Test plan

- [x] `cargo check --all-targets` passes locally
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes
- [x] PMAT TDG pre-push gate passes
- [ ] CI green on this PR
- [ ] sccache JSON stats file appears in `/var/log/ci-metrics` on intel after first run
- [ ] F9 falsify example reports observed hit-rate (after 7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)