### PR TITLE
feat(ci): opt in to cargo nextest run (Phase 2 pilot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       # Workspace with rash + runtime + wasm — moderate dep graph,
       # candidate for mid-range hit-rate signal between copia and aprender.
       enable_sccache: true
+      use_nextest: true
     secrets: inherit
 
   # Top-level gate: org ruleset requires status check named "gate" (exact match).


### PR DESCRIPTION
## Summary

Opt bashrs into `use_nextest: true` on the reusable sovereign-ci workflow (Refs PMAT-155).

This is the **Phase 2 nextest pilot** — same cohort as the Phase 3 sccache pilot (PMAT-151, merged in #197). `use_nextest` was just added as a `workflow_call` boolean input to `paiml/.github/.github/workflows/sovereign-ci.yml` (default `false`); this PR enrolls bashrs as one of three pilot repos (copia, bashrs, aprender).

## Measurement

- F11 baseline p95 for bashrs test job: **222s** (measured via `cargo run --example falsify_f11_test_job_p95` in paiml/infra#52).
- 7-day observation window after merge.
- If p95 ≤ 300s across the pilot cohort, we'll flip the reusable workflow's default to `true` fleet-wide.

## Changes

One-line YAML edit to `.github/workflows/ci.yml`: add `use_nextest: true` alongside the existing `enable_sccache: true` in the `with:` block of the `ci:` job. The caller-level `gate:` aggregator (added in #197) is untouched.

## Test plan

- [ ] CI runs green on this PR with `cargo nextest run` instead of `cargo test`
- [ ] F11 falsifier continues to report p95 ≤ 300s over the 7-day window post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)