### PR TITLE
fix(release): rustup target add to defeat workspace toolchain pin

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -91,6 +91,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The workspace pins a specific channel in `rust-toolchain.toml`
+      # which overrides the dtolnay action for any cargo invocation in
+      # the tree. Add the target explicitly to that pinned toolchain so
+      # native cross-compiles (x86_64-musl) don't fail with `can't find
+      # crate for core` mid-build.
+      - name: Install target on workspace-pinned toolchain
+        if: ${{ !matrix.cross }}
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |


### PR DESCRIPTION
## Summary

- Add explicit \`rustup target add\` after \`dtolnay/rust-toolchain@stable\` in \`binary-release.yml\` for native (\`!matrix.cross\`) targets.
- Same fix that landed in [forjar PR #124](https://github.com/paiml/forjar/pull/124).

## Why

\`rust-toolchain.toml\` pins channel \`1.93.0\` with no \`targets\` list. Any cargo invocation in the tree uses that pinned toolchain — so \`dtolnay/rust-toolchain@stable\`'s \`targets:\` parameter is silently overridden, and \`x86_64-unknown-linux-musl\` builds fail with:

\`\`\`
error[E0463]: can't find crate for \`core\`
\`\`\`

Three of four targets in v6.66.0's backfill (x86_64-musl, aarch64-musl, aarch64-gnu) are stuck on this. Only x86_64-gnu has been attaching because it's the toolchain's native target.

\`cross\` cross-compiles spawn their own Docker image that ignores the workspace pin, so the new step is gated on \`!matrix.cross\`.

## Test plan

- [ ] Merge → re-trigger v6.66.0 backfill via \`gh workflow run\` with \`tag=v6.66.0\`.
- [ ] Verify all 4 targets attach (x86_64 + aarch64 × musl + gnu).
- [ ] No regressions on x86_64-gnu (already working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)