### PR TITLE
ci: drop cargo package --verify (not a valid flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           echo "Version verified: $TAG_VER"
 
       - name: Verify bashrs package tarball
-        run: cargo package --verify -p bashrs --locked
+        run: cargo package -p bashrs --locked
 
       # `cargo publish -p bashrs` is idempotent in the sense that a re-publish
       # of an already-published version errors out — the workflow is designed


### PR DESCRIPTION
## Summary

The release.yml dispatch against v6.66.1 (run 25016693262) failed at the
\`Verify bashrs package tarball\` step:

\`\`\`
error: unexpected argument '--verify' found
  tip: a similar argument exists: '--no-verify'
\`\`\`

\`cargo package\` verifies the tarball by default; the only flag is
\`--no-verify\` to skip verification. Drop \`--verify\` to use the default.

## Test plan

- [ ] Merge
- [ ] workflow_dispatch release.yml against v6.66.1
- [ ] Confirm package + publish + release-create steps all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)