### PR TITLE
fix(oracle): point the extracted test module at the crate root (GH-214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
       # members with 0 errors (bashrs, bashrs_oracle, bashrs_runtime,
       # bashrs_specs, bashrs_wasm).
       test_workspace: true
+      # rash/src/testing/shellcheck_validation_tests.rs shells out to shellcheck
+      # and `.expect()`s it, so those 23 tests PANIC where it is absent. They
+      # never ran before because `--lib` scoped to the root stub package; turning
+      # test_workspace on is what surfaced them.
+      #
+      # Installed rather than skipped: that module asserts a stated critical
+      # invariant — "every generated script must pass `shellcheck -s sh`" — so
+      # skipping it in CI would swap a red for a silent green, which is the exact
+      # failure mode this repo keeps getting bitten by. infra's clean-room gate
+      # already installs shellcheck for bashrs for the same reason.
+      extra_pkgs: shellcheck
     secrets: inherit
 
   # Top-level gate: org ruleset requires status check named "gate" (exact match).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
       # candidate for mid-range hit-rate signal between copia and aprender.
       enable_sccache: true
       use_nextest: true
+      # GH-214: without this the reusable workflow runs `--lib`, which scopes to
+      # the ROOT package (bashrs-specs) and never builds rash/, bashrs-oracle,
+      # bashrs-runtime or bashrs-wasm. bashrs-oracle's test module therefore
+      # failed to compile for months while every check stayed green. `--workspace
+      # --lib` is what makes a rotting workspace member loud.
+      #
+      # Verified locally before enabling, because turning this on blind would red
+      # the whole pipeline: `cargo test --workspace --lib --no-run` builds all 5
+      # members with 0 errors (bashrs, bashrs_oracle, bashrs_runtime,
+      # bashrs_specs, bashrs_wasm).
+      test_workspace: true
     secrets: inherit
 
   # Top-level gate: org ruleset requires status check named "gate" (exact match).

--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.30.0",
-  "created_at": "2026-08-11T17:45:41.681652097Z",
+  "created_at": "2026-08-11T18:09:09.694699593Z",
   "git_context": null,
   "files": {
     "./bashrs-oracle/benches/classification.rs": {

--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.29.0",
-  "created_at": "2026-08-10T07:08:19.394754126Z",
+  "version": "3.30.0",
+  "created_at": "2026-08-11T17:45:41.681652097Z",
   "git_context": null,
   "files": {
     "./bashrs-oracle/benches/classification.rs": {
@@ -47,7 +47,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/benches/classification.rs",
@@ -284,7 +284,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/corpus.rs",
@@ -355,7 +355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 80.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/features.rs",
@@ -440,9 +440,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/generated_contracts.rs",
@@ -504,7 +504,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/lib.rs",
@@ -575,7 +575,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/lib_cont.rs",
@@ -637,7 +637,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-wasm/src/generated_contracts.rs",
@@ -699,7 +699,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.08572,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-wasm/src/lib.rs",
@@ -952,7 +952,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./benches/workspace_bench.rs",
@@ -1023,7 +1023,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 0.9,
         "language": "TypeScript",
         "file_path": "./editors/vscode/src/extension.ts",
@@ -1102,7 +1102,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/backup-clean.rs",
@@ -1173,7 +1173,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/backup-script.rs",
@@ -1244,7 +1244,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic/functions.rs",
@@ -1315,7 +1315,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic/variables.rs",
@@ -1386,7 +1386,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic.rs",
@@ -1457,7 +1457,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/build-automation.rs",
@@ -1528,7 +1528,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex01_basic_string.rs",
@@ -1590,7 +1590,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex02_integer_variables.rs",
@@ -1652,7 +1652,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex03_boolean_variables.rs",
@@ -1714,7 +1714,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex04_mixed_types.rs",
@@ -1776,7 +1776,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex05_special_chars.rs",
@@ -1838,7 +1838,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex06_path_variables.rs",
@@ -1900,7 +1900,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex07_paths_with_spaces.rs",
@@ -1962,7 +1962,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex08_configuration.rs",
@@ -2024,7 +2024,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex09_naming_conventions.rs",
@@ -2086,7 +2086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex10_unicode.rs",
@@ -2148,7 +2148,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex01_basic_function.rs",
@@ -2219,7 +2219,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex02_one_parameter.rs",
@@ -2290,7 +2290,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex03_multiple_params.rs",
@@ -2361,7 +2361,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex04_mixed_types.rs",
@@ -2432,7 +2432,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex05_function_composition.rs",
@@ -2503,7 +2503,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex06_helper_functions.rs",
@@ -2574,7 +2574,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex07_nested_calls.rs",
@@ -2645,7 +2645,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex08_installer_pattern.rs",
@@ -2716,7 +2716,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex09_many_parameters.rs",
@@ -2795,7 +2795,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex10_parameter_naming.rs",
@@ -2866,7 +2866,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex11_variadic_pattern.rs",
@@ -2937,7 +2937,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex12_two_stage_deployment.rs",
@@ -3008,7 +3008,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex01_basic_if.rs",
@@ -3079,7 +3079,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex02_if_else.rs",
@@ -3150,7 +3150,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex03_if_elif_else.rs",
@@ -3221,7 +3221,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex04_integer_comparisons.rs",
@@ -3292,7 +3292,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex05_string_comparison.rs",
@@ -3363,7 +3363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex06_logical_and.rs",
@@ -3434,7 +3434,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex07_logical_or.rs",
@@ -3505,7 +3505,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex08_not_operator.rs",
@@ -3576,7 +3576,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex09_nested_if.rs",
@@ -3647,7 +3647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex10_conditional_calls.rs",
@@ -3718,7 +3718,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex11_early_return.rs",
@@ -3789,7 +3789,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex12_guard_clauses.rs",
@@ -3860,7 +3860,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex13_complex_logic.rs",
@@ -3931,7 +3931,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex14_boolean_variables.rs",
@@ -4002,7 +4002,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex15_installer_logic.rs",
@@ -4073,7 +4073,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/conditional-logic.rs",
@@ -4144,7 +4144,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/config-manager.rs",
@@ -4215,7 +4215,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/control_flow/conditionals.rs",
@@ -4286,7 +4286,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 98.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/control_flow/loops.rs",
@@ -4365,7 +4365,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/download-install.rs",
@@ -4436,7 +4436,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/environment-setup.rs",
@@ -4507,7 +4507,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/error-handling.rs",
@@ -4578,7 +4578,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/factorial.rs",
@@ -4649,7 +4649,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/file-operations.rs",
@@ -4720,7 +4720,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/hello.rs",
@@ -4791,7 +4791,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/installer.rs",
@@ -4862,7 +4862,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/minimal.rs",
@@ -4933,7 +4933,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/node-installer.rs",
@@ -5004,7 +5004,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/package-manager.rs",
@@ -5075,7 +5075,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/rust-installer.rs",
@@ -5146,7 +5146,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/safety/escaping.rs",
@@ -5217,7 +5217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/safety/injection_prevention.rs",
@@ -5288,7 +5288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/simple.rs",
@@ -5359,7 +5359,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/stdlib_demo.rs",
@@ -5430,7 +5430,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/system-info.rs",
@@ -5501,7 +5501,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/user-functions.rs",
@@ -5572,7 +5572,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/xtask_integration/hooks/pre-commit.rs",
@@ -5643,7 +5643,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./fuzz/fuzz_targets/injection_detection.rs",
@@ -5714,7 +5714,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./fuzz/fuzz_targets/transpile_robustness.rs",
@@ -5776,7 +5776,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.31638,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/bash_purification_benchmarks.rs",
@@ -5855,7 +5855,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.89313,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/fix_safety_bench.rs",
@@ -5934,7 +5934,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/lint_performance.rs",
@@ -6005,7 +6005,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/make_parsing_bench.rs",
@@ -6155,7 +6155,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.33333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/makefile_benchmarks.rs",
@@ -6234,7 +6234,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.368935,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/tracing_overhead.rs",
@@ -6637,7 +6637,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/baselines.rs",
@@ -6708,7 +6708,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/contract_validation.rs",
@@ -6779,7 +6779,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/conversation_generator.rs",
@@ -6850,7 +6850,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/cwe_mapping_demo.rs",
@@ -6921,7 +6921,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/evaluation_metrics.rs",
@@ -7079,7 +7079,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/fast_classify_export.rs",
@@ -7229,7 +7229,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/label_audit.rs",
@@ -7379,7 +7379,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.67742,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/optimizer_benchmark.rs",
@@ -7458,7 +7458,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.67273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/quality_tools_demo.rs",
@@ -7545,7 +7545,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/safety_check.rs",
@@ -7616,7 +7616,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/shell_safety_classifier.rs",
@@ -7687,7 +7687,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/shellsafetybench.rs",
@@ -7758,7 +7758,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_data_pipeline.rs",
@@ -7829,7 +7829,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_report.rs",
@@ -7891,7 +7891,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_workflow.rs",
@@ -7962,7 +7962,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/tokenizer_validation.rs",
@@ -8191,7 +8191,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 96.948044,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/mod.rs",
@@ -8270,7 +8270,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.379486,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted.rs",
@@ -8363,9 +8363,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted_part2_incl2.rs",
@@ -8427,7 +8427,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 83.55068,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted_restrictedast.rs",
@@ -8601,7 +8601,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.073975,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/visitor.rs",
@@ -8688,7 +8688,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.55769,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/analysis_report.rs",
@@ -8767,7 +8767,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.232025,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast.rs",
@@ -8854,7 +8854,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.25325,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast_bashast.rs",
@@ -8939,9 +8939,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast_part2_incl2.rs",
@@ -9003,7 +9003,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/codegen.rs",
@@ -9074,7 +9074,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/generators.rs",
@@ -9145,7 +9145,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/lexer.rs",
@@ -9778,7 +9778,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.19825,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/parser_control.rs",
@@ -10039,7 +10039,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.63125,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/parser_expr.rs",
@@ -10229,7 +10229,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic.rs",
@@ -10395,7 +10395,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_default.rs",
@@ -10464,9 +10464,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_part2_incl2.rs",
@@ -10526,9 +10526,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_part3_incl2.rs",
@@ -10590,7 +10590,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/mod.rs",
@@ -10652,7 +10652,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.09877,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_expansion.rs",
@@ -10731,7 +10731,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.89285,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_prefix.rs",
@@ -10810,7 +10810,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.328766,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_string.rs",
@@ -11752,17 +11752,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 15.471698,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 91.337906,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part2_s3.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.528302,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 22.6%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -12610,7 +12627,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_6.rs",
@@ -13234,7 +13251,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_s6.rs",
@@ -13378,17 +13395,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.09091,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 92.80992,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_s8.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 35 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.9090908,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.5%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -13683,7 +13717,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_4.rs",
@@ -13754,7 +13788,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_5.rs",
@@ -13904,7 +13938,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_7.rs",
@@ -13975,7 +14009,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_8.rs",
@@ -14283,7 +14317,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s4.rs",
@@ -14354,7 +14388,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s5.rs",
@@ -14504,7 +14538,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s7.rs",
@@ -14575,7 +14609,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s8.rs",
@@ -14719,17 +14753,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 16.923077,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 6.5,
+        "total": 94.02098,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_10.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0769231,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.4%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -14787,7 +14838,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_2.rs",
@@ -14858,7 +14909,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_3.rs",
@@ -14927,13 +14978,22 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_4.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -15149,7 +15209,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.2943,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_7.rs",
@@ -15228,7 +15288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17418,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_8.rs",
@@ -15307,7 +15367,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.9199,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_9.rs",
@@ -15386,7 +15446,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_d.rs",
@@ -15536,7 +15596,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s2.rs",
@@ -15607,7 +15667,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s3.rs",
@@ -15678,7 +15738,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s4.rs",
@@ -15907,7 +15967,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.2943,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s7.rs",
@@ -15986,7 +16046,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17418,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s8.rs",
@@ -16065,7 +16125,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.9199,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s9.rs",
@@ -16239,7 +16299,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.059525,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/coverage/mod_branchinfo.rs",
@@ -16340,9 +16400,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/coverage/mod_part2_incl2.rs",
@@ -16404,7 +16464,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_score.rs",
@@ -16499,7 +16559,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_scoring.rs",
@@ -16592,9 +16652,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_scoring_part2_incl2.rs",
@@ -16656,7 +16716,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.08418,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter.rs",
@@ -16830,7 +16890,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_expr.rs",
@@ -16909,7 +16969,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.801025,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_formatter.rs",
@@ -17002,9 +17062,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_part2_incl2.rs",
@@ -17064,9 +17124,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_part3_incl2.rs",
@@ -17128,7 +17188,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/linter/mod.rs",
@@ -17190,7 +17250,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/linter/suppressions.rs",
@@ -17261,7 +17321,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/mod.rs",
@@ -17323,7 +17383,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/scoring/mod.rs",
@@ -17410,7 +17470,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/scoring_config.rs",
@@ -17568,7 +17628,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen.rs",
@@ -17637,9 +17697,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen_part2_incl2.rs",
@@ -17699,9 +17759,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen_part3_incl2.rs",
@@ -17858,7 +17918,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/mod.rs",
@@ -17929,7 +17989,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/patterns.rs",
@@ -18079,7 +18139,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/conditional_exprs.rs",
@@ -18237,7 +18297,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/expressions.rs",
@@ -18316,7 +18376,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/mod.rs",
@@ -18387,7 +18447,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.46032,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/tests.rs",
@@ -18466,7 +18526,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/test_generator.rs",
@@ -18616,7 +18676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/type_check.rs",
@@ -18687,7 +18747,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/type_check_default.rs",
@@ -18758,7 +18818,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/bashrs.rs",
@@ -18829,7 +18889,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/quality-dashboard.rs",
@@ -18900,7 +18960,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/quality-gate.rs",
@@ -19137,7 +19197,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/adversarial_commands.rs",
@@ -19216,7 +19276,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60564,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args.rs",
@@ -19253,68 +19313,68 @@
     },
     "./rash/src/cli/args_corpus.rs": {
       "content_hash": [
-        28,
-        163,
-        120,
-        46,
-        131,
-        86,
-        161,
-        63,
-        171,
-        216,
-        154,
-        99,
-        168,
-        255,
-        118,
-        236,
-        249,
-        122,
-        41,
-        51,
-        59,
-        92,
-        109,
-        255,
-        93,
-        141,
-        122,
+        202,
         90,
-        84,
-        150,
-        3,
-        107
+        239,
+        103,
+        182,
+        83,
+        58,
+        52,
+        5,
+        168,
+        66,
+        236,
+        83,
+        167,
+        199,
+        162,
+        159,
+        146,
+        206,
+        204,
+        87,
+        28,
+        183,
+        31,
+        236,
+        50,
+        108,
+        156,
+        28,
+        74,
+        50,
+        137
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 12.639999,
+        "duplication_ratio": 16.666666,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 97.64,
-        "grade": "APlus",
+        "entropy_score": 9.5,
+        "total": 96.51515,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_corpus.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 5.0,
+            "amount": 0.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 18 duplicate code patterns"
+            "issue": "Found 1 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 7.36,
+            "amount": 3.3333335,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 36.8%"
+            "issue": "Code duplication: 16.7%"
           }
         ],
         "critical_defects_count": 0,
@@ -19332,52 +19392,281 @@
     },
     "./rash/src/cli/args_corpus_analysis.rs": {
       "content_hash": [
-        104,
-        98,
-        107,
-        18,
-        24,
-        250,
-        244,
-        124,
-        204,
+        236,
         29,
-        239,
-        112,
-        211,
-        132,
-        133,
-        102,
-        33,
-        119,
-        20,
-        252,
-        26,
-        6,
-        104,
-        74,
-        176,
-        178,
-        43,
-        0,
-        89,
-        135,
+        83,
+        159,
+        92,
         123,
-        81
+        243,
+        4,
+        219,
+        117,
+        31,
+        28,
+        15,
+        144,
+        127,
+        229,
+        60,
+        36,
+        176,
+        103,
+        164,
+        44,
+        84,
+        103,
+        78,
+        221,
+        147,
+        203,
+        217,
+        159,
+        57,
+        204
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 12.890625,
+        "duplication_ratio": 16.923077,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 96.74826,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0769231,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.4%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_diag.rs": {
+      "content_hash": [
+        131,
+        108,
+        33,
+        17,
+        163,
+        69,
+        31,
+        72,
+        202,
+        188,
+        191,
+        188,
+        191,
+        118,
+        179,
+        21,
+        249,
+        135,
+        140,
+        9,
+        11,
+        215,
+        141,
+        19,
+        243,
+        255,
+        96,
+        110,
+        252,
+        113,
+        166,
+        218
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis_diag.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_gates.rs": {
+      "content_hash": [
+        108,
+        236,
+        76,
+        105,
+        130,
+        54,
+        25,
+        169,
+        20,
+        21,
+        207,
+        246,
+        31,
+        135,
+        143,
+        115,
+        229,
+        229,
+        142,
+        39,
+        201,
+        170,
+        127,
+        226,
+        29,
+        199,
+        152,
+        161,
+        187,
+        48,
+        80,
+        124
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.666666,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.0,
+        "total": 94.242424,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis_gates.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 6 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.3333335,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_pipeline.rs": {
+      "content_hash": [
+        30,
+        70,
+        248,
+        136,
+        26,
+        59,
+        82,
+        109,
+        122,
+        75,
+        238,
+        88,
+        249,
+        109,
+        18,
+        87,
+        159,
+        194,
+        14,
+        224,
+        200,
+        251,
+        248,
+        19,
+        102,
+        181,
+        113,
+        230,
+        60,
+        36,
+        89,
+        174
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 11.655629,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 97.890625,
-        "grade": "APlus",
+        "total": 96.655624,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
-        "file_path": "./rash/src/cli/args_corpus_analysis.rs",
+        "file_path": "./rash/src/cli/args_corpus_analysis_pipeline.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
@@ -19385,15 +19674,244 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 22 duplicate code patterns"
+            "issue": "Found 18 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 7.109375,
+            "amount": 8.344371,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 35.5%"
+            "issue": "Code duplication: 41.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_diagnostics.rs": {
+      "content_hash": [
+        129,
+        158,
+        58,
+        44,
+        25,
+        56,
+        215,
+        221,
+        124,
+        121,
+        131,
+        235,
+        177,
+        4,
+        96,
+        174,
+        10,
+        50,
+        141,
+        116,
+        177,
+        67,
+        176,
+        81,
+        30,
+        35,
+        113,
+        2,
+        194,
+        40,
+        243,
+        55
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_diagnostics.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_operations.rs": {
+      "content_hash": [
+        198,
+        113,
+        31,
+        1,
+        176,
+        31,
+        182,
+        112,
+        205,
+        182,
+        153,
+        163,
+        104,
+        190,
+        129,
+        51,
+        249,
+        255,
+        43,
+        136,
+        27,
+        186,
+        121,
+        20,
+        63,
+        149,
+        200,
+        123,
+        172,
+        205,
+        32,
+        187
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.294117,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.5,
+        "total": 92.5401,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_operations.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.7058825,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 23.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_scoring.rs": {
+      "content_hash": [
+        51,
+        199,
+        71,
+        240,
+        159,
+        183,
+        180,
+        60,
+        233,
+        206,
+        120,
+        201,
+        74,
+        168,
+        167,
+        185,
+        175,
+        239,
+        172,
+        111,
+        251,
+        207,
+        113,
+        218,
+        2,
+        173,
+        15,
+        146,
+        227,
+        115,
+        154,
+        235
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 11.044776,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.04478,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_scoring.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 8.955224,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 44.8%"
           }
         ],
         "critical_defects_count": 0,
@@ -19453,7 +19971,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.64285,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_ext.rs",
@@ -19532,7 +20050,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.916336,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_tools.rs",
@@ -19862,9 +20380,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_part2_incl2.rs",
@@ -19924,9 +20442,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_part3_incl2.rs",
@@ -20075,7 +20593,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.8,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_verify.rs",
@@ -20154,7 +20672,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/cfg_commands.rs",
@@ -20225,7 +20743,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/chat_inference.rs",
@@ -20296,7 +20814,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/classify_commands.rs",
@@ -20391,7 +20909,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/color.rs",
@@ -20420,48 +20938,48 @@
     },
     "./rash/src/cli/commands.rs": {
       "content_hash": [
-        157,
-        97,
-        118,
-        38,
-        189,
-        116,
+        125,
+        82,
+        69,
+        115,
+        111,
         110,
-        110,
-        67,
-        85,
-        206,
-        253,
-        164,
-        166,
-        60,
-        245,
-        97,
-        255,
-        49,
-        167,
-        110,
-        140,
-        175,
-        162,
-        124,
-        15,
-        2,
-        134,
-        109,
+        168,
+        89,
+        139,
+        231,
+        204,
+        40,
+        72,
+        200,
+        179,
         47,
-        108,
-        251
+        102,
+        145,
+        28,
+        252,
+        197,
+        144,
+        120,
+        18,
+        194,
+        236,
+        90,
+        153,
+        22,
+        185,
+        154,
+        158
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.71605,
+        "duplication_ratio": 17.73006,
         "coupling_score": 12.8,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 91.37823,
+        "total": 91.39096,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -20477,11 +20995,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.2839506,
+            "amount": 2.2699385,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 11.4%"
+            "issue": "Code duplication: 11.3%"
           },
           {
             "source_metric": "Coupling",
@@ -20636,7 +21154,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.4,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/comply_commands.rs",
@@ -20731,7 +21249,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.27315,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/config_commands.rs",
@@ -20826,7 +21344,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.76363,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_advanced_commands.rs",
@@ -20964,6 +21482,85 @@
       },
       "git_context": null
     },
+    "./rash/src/cli/corpus_analysis_dispatch.rs": {
+      "content_hash": [
+        33,
+        215,
+        85,
+        88,
+        197,
+        211,
+        180,
+        97,
+        171,
+        157,
+        28,
+        25,
+        226,
+        8,
+        51,
+        213,
+        19,
+        38,
+        222,
+        89,
+        159,
+        199,
+        11,
+        181,
+        203,
+        224,
+        114,
+        95,
+        0,
+        36,
+        175,
+        44
+      ],
+      "score": {
+        "structural_complexity": 10.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 90.0,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/corpus_analysis_dispatch.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 16 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 64"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
     "./rash/src/cli/corpus_b2_commands.rs": {
       "content_hash": [
         127,
@@ -21008,7 +21605,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_b2_commands.rs",
@@ -21103,7 +21700,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_b2_fix_commands.rs",
@@ -21198,7 +21795,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.82846,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_compare_commands.rs",
@@ -21301,7 +21898,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.11329,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands.rs",
@@ -21396,7 +21993,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_corpus.rs",
@@ -21546,7 +22143,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.18622,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_corpus_4.rs",
@@ -21639,9 +22236,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_part2_incl2.rs",
@@ -21703,7 +22300,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.77246,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_convergence_commands.rs",
@@ -21764,38 +22361,38 @@
     },
     "./rash/src/cli/corpus_core_commands.rs": {
       "content_hash": [
-        171,
-        156,
-        48,
-        30,
-        39,
-        32,
-        67,
-        20,
-        161,
-        162,
-        189,
-        165,
-        121,
-        55,
-        15,
-        126,
-        118,
         183,
-        125,
-        147,
-        155,
-        113,
-        18,
+        106,
+        5,
+        52,
+        51,
+        141,
+        2,
         77,
-        194,
-        219,
-        148,
-        62,
-        88,
-        99,
-        62,
-        41
+        96,
+        74,
+        250,
+        118,
+        20,
+        8,
+        69,
+        116,
+        23,
+        60,
+        68,
+        243,
+        200,
+        95,
+        75,
+        154,
+        244,
+        90,
+        89,
+        199,
+        221,
+        217,
+        249,
+        91
       ],
       "score": {
         "structural_complexity": 10.0,
@@ -21804,8 +22401,8 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 90.0,
+        "entropy_score": 7.5,
+        "total": 92.5,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -21813,11 +22410,11 @@
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 5.0,
+            "amount": 2.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 19 duplicate code patterns"
+            "issue": "Found 5 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -21825,7 +22422,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 152"
+            "issue": "High cyclomatic complexity: 87"
           }
         ],
         "critical_defects_count": 0,
@@ -21885,7 +22482,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60365,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_decision_commands.rs",
@@ -22225,7 +22822,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_entry_commands.rs",
@@ -22296,7 +22893,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_expansion_commands.rs",
@@ -22462,7 +23059,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.587006,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_gate_commands.rs",
@@ -22565,7 +23162,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.65,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_metrics_commands.rs",
@@ -22660,7 +23257,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.36757,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ml_commands.rs",
@@ -22834,7 +23431,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.18605,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_pipeline_commands.rs",
@@ -23000,7 +23597,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_report_commands.rs",
@@ -23087,7 +23684,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_score_print_commands.rs",
@@ -23261,7 +23858,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_corpus.rs",
@@ -23330,9 +23927,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_part2_incl2.rs",
@@ -23394,7 +23991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.89731,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_toolcheck.rs",
@@ -23489,7 +24086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.35308,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_tier_commands.rs",
@@ -23576,7 +24173,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_time_commands.rs",
@@ -23671,7 +24268,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.73334,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_viz_commands.rs",
@@ -23766,7 +24363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.882355,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_weight_commands.rs",
@@ -23940,7 +24537,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/devcontainer_commands.rs",
@@ -24011,7 +24608,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_commands.rs",
@@ -24090,7 +24687,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.92157,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_profile_commands.rs",
@@ -24193,7 +24790,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.52307,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_validate_commands.rs",
@@ -24288,7 +24885,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/explain_command.rs",
@@ -24454,7 +25051,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/format_commands.rs",
@@ -24533,7 +25130,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/gate_commands.rs",
@@ -24620,7 +25217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_commands.rs",
@@ -24802,7 +25399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.407005,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_logic.rs",
@@ -24889,7 +25486,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.64138,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_run_logic.rs",
@@ -24992,7 +25589,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/lint_commands.rs",
@@ -25079,7 +25676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic.rs",
@@ -25245,7 +25842,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.16892,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_format.rs",
@@ -25443,7 +26040,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_shell.rs",
@@ -25514,7 +26111,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_validate.rs",
@@ -25646,38 +26243,38 @@
     },
     "./rash/src/cli/mod.rs": {
       "content_hash": [
+        51,
         59,
-        43,
-        27,
-        191,
-        49,
-        56,
-        140,
-        23,
-        139,
-        194,
-        167,
-        238,
-        149,
-        103,
-        234,
-        63,
-        242,
+        126,
+        253,
+        231,
+        0,
         99,
-        102,
-        153,
-        35,
-        18,
-        10,
-        24,
-        179,
-        149,
-        122,
-        220,
+        192,
+        173,
+        177,
+        71,
+        101,
+        127,
+        152,
+        29,
+        124,
+        116,
+        44,
+        70,
+        36,
+        1,
         150,
-        202,
-        146,
-        251
+        189,
+        250,
+        137,
+        120,
+        65,
+        37,
+        195,
+        227,
+        3,
+        235
       ],
       "score": {
         "structural_complexity": 25.0,
@@ -25688,7 +26285,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/mod.rs",
@@ -25924,7 +26521,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.49091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/property_commands.rs",
@@ -26177,7 +26774,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/score_commands.rs",
@@ -26620,7 +27217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/watch_commands.rs",
@@ -26723,7 +27320,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/loader.rs",
@@ -26794,7 +27391,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/mod.rs",
@@ -26944,7 +27541,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/tests.rs",
@@ -27015,7 +27612,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/config.rs",
@@ -27181,7 +27778,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 95.41322,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/mod.rs",
@@ -27260,7 +27857,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.26568,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/rules.rs",
@@ -27545,7 +28142,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.31457,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/runner.rs",
@@ -27640,7 +28237,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/scoring.rs",
@@ -27711,7 +28308,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.893616,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/tests.rs",
@@ -27820,8 +28417,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -27877,7 +28475,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/analyzer.rs",
@@ -27948,7 +28546,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.82761,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/deduplicator.rs",
@@ -28035,7 +28633,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/mod.rs",
@@ -28106,7 +28704,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.99123,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/nondeterminism.rs",
@@ -28136,8 +28734,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -28272,7 +28871,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.3,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/quoter.rs",
@@ -28294,8 +28893,9 @@
             "issue": "High cognitive complexity: 34"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -28351,7 +28951,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/container/distroless.rs",
@@ -28422,7 +29022,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/container/mod.rs",
@@ -28656,9 +29256,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/adversarial_templates_part2_incl2.rs",
@@ -28720,7 +29320,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 99.66667,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/adversarial_templates_unsafe.rs",
@@ -28799,7 +29399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/baselines.rs",
@@ -28870,7 +29470,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.48541,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/benchmark_export.rs",
@@ -28957,7 +29557,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/benchmark_publish.rs",
@@ -29107,7 +29707,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.09722,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/classifier.rs",
@@ -29194,7 +29794,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/contract_validation.rs",
@@ -29265,7 +29865,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.90849,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/convergence.rs",
@@ -29352,7 +29952,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/conversations.rs",
@@ -29502,7 +30102,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset.rs",
@@ -29589,7 +30189,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.67778,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_derive.rs",
@@ -29684,7 +30284,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_export.rs",
@@ -29763,7 +30363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.5,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_exportformat.rs",
@@ -29927,9 +30527,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_part2_incl2.rs",
@@ -29989,9 +30589,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_part3_incl2.rs",
@@ -30053,7 +30653,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.746994,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/domain_categories.rs",
@@ -30322,7 +30922,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/evaluation.rs",
@@ -30393,7 +30993,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.6,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/expansion_generator.rs",
@@ -30480,7 +31080,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/graph_priority.rs",
@@ -30630,7 +31230,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 97.045456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/mod.rs",
@@ -30962,7 +31562,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.82222,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/quality_gates.rs",
@@ -31057,7 +31657,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data.rs",
@@ -31128,7 +31728,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_corpusregistry.rs",
@@ -31199,7 +31799,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_load.rs",
@@ -31268,9 +31868,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_part2_incl2.rs",
@@ -31332,7 +31932,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/mod.rs",
@@ -31419,7 +32019,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.61539,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/runner.rs",
@@ -31593,7 +32193,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/runner_cont_4.rs",
@@ -31916,7 +32516,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/schema_enforcement.rs",
@@ -32098,7 +32698,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/schema_enforcement_part2_incl2.rs",
@@ -32239,7 +32839,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.4968,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/tier_analysis.rs",
@@ -32421,7 +33021,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/training_config.rs",
@@ -32666,7 +33266,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile.rs",
@@ -32737,7 +33337,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_cont.rs",
@@ -32799,7 +33399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_converter.rs",
@@ -32894,7 +33494,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.63576,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_coverage_tests2.rs",
@@ -32971,9 +33571,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_part2_incl2.rs",
@@ -33035,7 +33635,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 97.226105,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/mod.rs",
@@ -33201,7 +33801,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.55351,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/posix_emit_ir.rs",
@@ -33391,7 +33991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.63367,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/posix_runtime.rs",
@@ -33557,7 +34157,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/trace.rs",
@@ -33619,7 +34219,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/abstract_state.rs",
@@ -33690,7 +34290,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/emitter.rs",
@@ -33761,7 +34361,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.9284,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state.rs",
@@ -33848,7 +34448,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.90807,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state_enhancedfilesystementry.rs",
@@ -33933,9 +34533,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state_part2_incl2.rs",
@@ -34076,7 +34676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.489655,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/kani_harnesses.rs",
@@ -34163,7 +34763,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/mod.rs",
@@ -34313,7 +34913,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.77778,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/semantics.rs",
@@ -34408,7 +35008,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/tiny_ast.rs",
@@ -34422,8 +35022,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -34566,7 +35167,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/dialect.rs",
@@ -34604,8 +35205,9 @@
             "issue": "High cyclomatic complexity: 58"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 15,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -34661,7 +35263,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.5545,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/engine.rs",
@@ -34835,7 +35437,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/mod.rs",
@@ -34906,7 +35508,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/source_map.rs",
@@ -35054,9 +35656,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/transforms_part2_incl2.rs",
@@ -35118,7 +35720,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/types.rs",
@@ -35268,7 +35870,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.33333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/generated_contracts.rs",
@@ -35434,7 +36036,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60477,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_audit.rs",
@@ -35521,7 +36123,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.815125,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_auditcontext.rs",
@@ -35701,9 +36303,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part2_incl2.rs",
@@ -35763,9 +36365,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part3_incl2.rs",
@@ -35825,9 +36427,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part4_incl2.rs",
@@ -36047,7 +36649,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container.rs",
@@ -36126,7 +36728,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_containerruntime.rs",
@@ -36205,7 +36807,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_matrixsummary.rs",
@@ -36274,9 +36876,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_part2_incl2.rs",
@@ -36338,7 +36940,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.02829,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/distributed.rs",
@@ -36504,7 +37106,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.74707,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/dry_run_dryrunsummary.rs",
@@ -36583,7 +37185,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.38763,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/executor.rs",
@@ -36678,7 +37280,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/falsification.rs",
@@ -36749,7 +37351,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/from_bash.rs",
@@ -36828,7 +37430,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/from_bash_generate.rs",
@@ -37071,9 +37673,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/golden_trace_part2_incl2.rs",
@@ -37230,7 +37832,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/metrics.rs",
@@ -37301,7 +37903,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/metrics_format.rs",
@@ -37372,7 +37974,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/mod.rs",
@@ -37443,7 +38045,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/plan.rs",
@@ -37607,9 +38209,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/progress_part2_incl2.rs",
@@ -37671,7 +38273,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/progress_stepstate.rs",
@@ -37758,7 +38360,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/rollback.rs",
@@ -37908,7 +38510,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 99.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/spec.rs",
@@ -38145,7 +38747,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/tracing_logger.rs",
@@ -38216,7 +38818,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.08694,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert.rs",
@@ -38382,7 +38984,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.754486,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert_expr_tests3.rs",
@@ -38548,7 +39150,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.553955,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert_stmt.rs",
@@ -38722,7 +39324,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/effects.rs",
@@ -38888,7 +39490,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.74074,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/expr_calls.rs",
@@ -38983,7 +39585,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 95.61497,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/mod.rs",
@@ -39149,7 +39751,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.04211,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/pattern.rs",
@@ -39244,7 +39846,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.77313,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/shell_ir.rs",
@@ -39339,7 +39941,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.828575,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/tests.rs",
@@ -39505,7 +40107,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/autofix.rs",
@@ -39663,7 +40265,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic.rs",
@@ -39734,7 +40336,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_lintresult.rs",
@@ -39803,9 +40405,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_part2_incl2.rs",
@@ -39867,7 +40469,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_span.rs",
@@ -39938,7 +40540,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/docker_profiler.rs",
@@ -40112,7 +40714,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.3,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/ignore_file.rs",
@@ -40199,7 +40801,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.525925,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/make_preprocess.rs",
@@ -40237,8 +40839,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -40294,7 +40897,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 97.66457,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/mod.rs",
@@ -40452,7 +41055,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry.rs",
@@ -40523,7 +41126,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data.rs",
@@ -40594,7 +41197,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.8877,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_1.rs",
@@ -40673,7 +41276,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.764046,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_11.rs",
@@ -40752,7 +41355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.80899,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_12.rs",
@@ -40910,7 +41513,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 98.68065,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_2.rs",
@@ -40989,7 +41592,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 98.915665,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_3.rs",
@@ -41147,7 +41750,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.621414,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_4.rs",
@@ -41226,7 +41829,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.95681,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_4_more.rs",
@@ -41305,7 +41908,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_ext.rs",
@@ -41534,7 +42137,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.33312,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash003.rs",
@@ -41629,7 +42232,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.78571,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash004.rs",
@@ -41716,7 +42319,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.4279,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash005.rs",
@@ -41890,7 +42493,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.791306,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash007.rs",
@@ -42222,7 +42825,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.39139,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/coursera.rs",
@@ -42317,7 +42920,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/det001.rs",
@@ -42633,7 +43236,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.868546,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/devcontainer.rs",
@@ -42728,7 +43331,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/devcontainer_logic.rs",
@@ -42965,7 +43568,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker003.rs",
@@ -43044,7 +43647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker004.rs",
@@ -43115,7 +43718,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker005.rs",
@@ -43186,7 +43789,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker006.rs",
@@ -43257,7 +43860,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.19292,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker007.rs",
@@ -43526,7 +44129,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17143,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker010.rs",
@@ -43605,7 +44208,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker010_logic.rs",
@@ -43921,7 +44524,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/idem002.rs",
@@ -44014,8 +44617,9 @@
             "issue": "Code duplication: 10.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -44071,7 +44675,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.06207,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/launchd001.rs",
@@ -44324,7 +44928,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make003.rs",
@@ -44482,7 +45086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.9713,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make005.rs",
@@ -44569,7 +45173,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.76364,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make006.rs",
@@ -44743,7 +45347,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.71658,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make008.rs",
@@ -44996,7 +45600,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.28926,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make011.rs",
@@ -45644,7 +46248,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.32468,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make019.rs",
@@ -45810,7 +46414,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod.rs",
@@ -45872,7 +46476,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_helpers.rs",
@@ -45934,7 +46538,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint.rs",
@@ -46005,7 +46609,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint_2.rs",
@@ -46076,7 +46680,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint_more.rs",
@@ -46136,9 +46740,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_part2_incl2.rs",
@@ -46200,7 +46804,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_std.rs",
@@ -46271,7 +46875,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf001.rs",
@@ -46285,8 +46889,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46342,7 +46947,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.37573,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf002.rs",
@@ -46437,7 +47042,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf003.rs",
@@ -46451,8 +47056,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46508,7 +47114,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.252525,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf004.rs",
@@ -46530,8 +47136,9 @@
             "issue": "Code duplication: 11.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46609,8 +47216,9 @@
             "issue": "Code duplication: 13.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46666,7 +47274,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.53669,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port001.rs",
@@ -46688,8 +47296,9 @@
             "issue": "Code duplication: 12.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46745,7 +47354,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port002.rs",
@@ -46816,7 +47425,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.8134,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port003.rs",
@@ -46895,7 +47504,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port004.rs",
@@ -46909,8 +47518,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46966,7 +47576,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port005.rs",
@@ -47037,7 +47647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.04638,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/rel001.rs",
@@ -47059,8 +47669,9 @@
             "issue": "Code duplication: 12.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47116,7 +47727,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/rel002.rs",
@@ -47225,8 +47836,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47391,8 +48003,9 @@
             "issue": "Code duplication: 11.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47527,7 +48140,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1004.rs",
@@ -47843,7 +48456,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1012.rs",
@@ -47914,7 +48527,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.344345,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1014.rs",
@@ -47936,8 +48549,9 @@
             "issue": "Code duplication: 10.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47993,7 +48607,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.570114,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1017.rs",
@@ -48072,7 +48686,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.570114,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1018.rs",
@@ -48238,7 +48852,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.79889,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1026.rs",
@@ -48260,8 +48874,9 @@
             "issue": "Code duplication: 10.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48404,7 +49019,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.72728,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1035.rs",
@@ -48513,8 +49128,9 @@
             "issue": "Code duplication: 18.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48649,7 +49265,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.862465,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1038.rs",
@@ -48815,7 +49431,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1041.rs",
@@ -48829,8 +49445,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48916,8 +49533,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48973,7 +49591,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 97.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1045.rs",
@@ -49052,7 +49670,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.090904,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1065.rs",
@@ -49074,8 +49692,9 @@
             "issue": "Code duplication: 12.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49131,7 +49750,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.78788,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1066.rs",
@@ -49153,8 +49772,9 @@
             "issue": "Code duplication: 10.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49210,7 +49830,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 97.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1068.rs",
@@ -49297,7 +49917,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1069.rs",
@@ -49368,7 +49988,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.4282,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1075.rs",
@@ -49390,8 +50010,9 @@
             "issue": "Code duplication: 10.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49447,7 +50068,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.366,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1076.rs",
@@ -49526,7 +50147,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.29838,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1078.rs",
@@ -49613,7 +50234,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 95.72728,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1079.rs",
@@ -49692,7 +50313,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.12987,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1082.rs",
@@ -49937,7 +50558,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.882744,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1086.rs",
@@ -49959,8 +50580,9 @@
             "issue": "Code duplication: 10.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50046,8 +50668,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50103,7 +50726,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.89375,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1090.rs",
@@ -50190,7 +50813,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.86363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1091.rs",
@@ -50364,7 +50987,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1095.rs",
@@ -50435,7 +51058,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.061424,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1097.rs",
@@ -50457,8 +51080,9 @@
             "issue": "Code duplication: 12.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50514,7 +51138,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1098.rs",
@@ -50743,7 +51367,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.16645,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1101.rs",
@@ -50980,7 +51604,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1106.rs",
@@ -51146,7 +51770,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1110.rs",
@@ -51217,7 +51841,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1111.rs",
@@ -51604,7 +52228,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.38961,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1120.rs",
@@ -51849,7 +52473,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1129.rs",
@@ -51920,7 +52544,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.30121,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1131.rs",
@@ -51999,7 +52623,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1135.rs",
@@ -52070,7 +52694,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.482605,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1139.rs",
@@ -52266,8 +52890,9 @@
             "issue": "Code duplication: 23.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 10,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52345,8 +52970,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52424,8 +53050,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52481,7 +53108,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.143326,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2004.rs",
@@ -52503,8 +53130,9 @@
             "issue": "Code duplication: 11.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52582,8 +53210,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52639,7 +53268,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.73334,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2006.rs",
@@ -52669,8 +53298,9 @@
             "issue": "High cognitive complexity: 22"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52748,8 +53378,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52827,8 +53458,9 @@
             "issue": "Code duplication: 17.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52906,8 +53538,9 @@
             "issue": "Code duplication: 16.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52963,7 +53596,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2010.rs",
@@ -52977,8 +53610,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53034,7 +53668,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2011.rs",
@@ -53048,8 +53682,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53105,7 +53740,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2012.rs",
@@ -53119,8 +53754,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53176,7 +53812,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2013.rs",
@@ -53190,8 +53826,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53247,7 +53884,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2014.rs",
@@ -53261,8 +53898,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53340,8 +53978,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53419,8 +54058,9 @@
             "issue": "Code duplication: 18.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53498,8 +54138,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53577,8 +54218,9 @@
             "issue": "Code duplication: 13.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53656,8 +54298,9 @@
             "issue": "Code duplication: 13.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53735,8 +54378,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53814,8 +54458,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53893,8 +54538,9 @@
             "issue": "Code duplication: 18.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53972,8 +54618,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54029,7 +54676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2024.rs",
@@ -54130,8 +54777,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54209,8 +54857,9 @@
             "issue": "Code duplication: 12.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54288,8 +54937,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54367,8 +55017,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54446,8 +55097,9 @@
             "issue": "Code duplication: 15.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54525,8 +55177,9 @@
             "issue": "Code duplication: 14.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54612,8 +55265,9 @@
             "issue": "High cognitive complexity: 46"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54691,8 +55345,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54770,8 +55425,9 @@
             "issue": "Code duplication: 19.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54849,8 +55505,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55080,7 +55737,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.683334,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2037.rs",
@@ -55110,8 +55767,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55189,8 +55847,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55246,7 +55905,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.666664,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2039.rs",
@@ -55268,8 +55927,9 @@
             "issue": "Code duplication: 26.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55347,8 +56007,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55404,7 +56065,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.84729,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2041.rs",
@@ -55434,8 +56095,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55513,8 +56175,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55592,8 +56255,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55671,8 +56335,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55750,8 +56415,9 @@
             "issue": "Code duplication: 20.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55829,8 +56495,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55908,8 +56575,9 @@
             "issue": "Code duplication: 12.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55987,8 +56655,9 @@
             "issue": "Code duplication: 15.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56066,8 +56735,9 @@
             "issue": "Code duplication: 22.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56145,8 +56815,9 @@
             "issue": "Code duplication: 12.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56224,8 +56895,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56303,8 +56975,9 @@
             "issue": "Code duplication: 15.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56390,8 +57063,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56469,8 +57143,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56548,8 +57223,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56627,8 +57303,9 @@
             "issue": "Code duplication: 17.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56706,8 +57383,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56864,8 +57542,9 @@
             "issue": "Code duplication: 24.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56943,8 +57622,9 @@
             "issue": "Code duplication: 17.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57022,8 +57702,9 @@
             "issue": "Code duplication: 14.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57109,8 +57790,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57188,8 +57870,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57245,7 +57928,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2064.rs",
@@ -57316,7 +57999,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2064_logic.rs",
@@ -57330,8 +58013,9 @@
             "issue": "Found 7 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57496,8 +58180,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57575,8 +58260,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57654,8 +58340,9 @@
             "issue": "Code duplication: 20.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57733,8 +58420,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57812,8 +58500,9 @@
             "issue": "Code duplication: 14.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57891,8 +58580,9 @@
             "issue": "Code duplication: 19.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57948,7 +58638,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.17842,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2072.rs",
@@ -57970,8 +58660,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58049,8 +58740,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58128,8 +58820,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58207,8 +58900,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58286,8 +58980,9 @@
             "issue": "Code duplication: 14.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58365,8 +59060,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58444,8 +59140,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58523,8 +59220,9 @@
             "issue": "Code duplication: 18.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58610,8 +59308,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58689,8 +59388,9 @@
             "issue": "Code duplication: 19.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58768,8 +59468,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58926,8 +59627,9 @@
             "issue": "Code duplication: 17.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59005,8 +59707,9 @@
             "issue": "Code duplication: 14.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59062,7 +59765,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2086.rs",
@@ -59218,9 +59921,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2086_part2_incl2.rs",
@@ -59304,8 +60007,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59462,8 +60166,9 @@
             "issue": "Code duplication: 17.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59541,8 +60246,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59620,8 +60326,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59677,7 +60384,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2092.rs",
@@ -59707,8 +60414,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59786,8 +60494,9 @@
             "issue": "Code duplication: 22.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59843,7 +60552,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.76666,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2094.rs",
@@ -59952,8 +60661,9 @@
             "issue": "Code duplication: 23.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 9,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60009,7 +60719,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2096.rs",
@@ -60031,8 +60741,9 @@
             "issue": "High cognitive complexity: 40"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60110,8 +60821,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60189,8 +60901,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 12,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60268,8 +60981,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60347,8 +61061,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60426,8 +61141,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60483,7 +61199,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.022095,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2102.rs",
@@ -60513,8 +61229,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60592,8 +61309,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60649,7 +61367,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.963005,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2104.rs",
@@ -60679,8 +61397,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60758,8 +61477,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60837,8 +61557,9 @@
             "issue": "Code duplication: 18.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60916,8 +61637,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60995,8 +61717,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61074,8 +61797,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61153,8 +61877,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61232,8 +61957,9 @@
             "issue": "Code duplication: 14.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61311,8 +62037,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61390,8 +62117,9 @@
             "issue": "Code duplication: 17.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61469,8 +62197,9 @@
             "issue": "Code duplication: 18.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61548,8 +62277,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61627,8 +62357,9 @@
             "issue": "Code duplication: 13.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61684,7 +62415,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.28863,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2117.rs",
@@ -61714,8 +62445,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61793,8 +62525,9 @@
             "issue": "Code duplication: 14.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61850,7 +62583,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.379166,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2119.rs",
@@ -61880,8 +62613,9 @@
             "issue": "High cognitive complexity: 27"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61937,7 +62671,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.076996,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2120.rs",
@@ -61967,8 +62701,9 @@
             "issue": "High cognitive complexity: 29"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62046,8 +62781,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62125,8 +62861,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62204,8 +62941,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62283,8 +63021,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62340,7 +63079,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.005615,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2125.rs",
@@ -62370,8 +63109,9 @@
             "issue": "High cognitive complexity: 32"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62449,8 +63189,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62528,8 +63269,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62585,7 +63327,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.287964,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2128.rs",
@@ -62615,8 +63357,9 @@
             "issue": "High cognitive complexity: 22"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62672,7 +63415,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.782394,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2129.rs",
@@ -62702,8 +63445,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62860,8 +63604,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62917,7 +63662,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.43827,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2132.rs",
@@ -62947,8 +63692,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63026,8 +63772,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63105,8 +63852,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63184,8 +63932,9 @@
             "issue": "Code duplication: 22.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63263,8 +64012,9 @@
             "issue": "Code duplication: 20.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63342,8 +64092,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63421,8 +64172,9 @@
             "issue": "Code duplication: 20.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63500,8 +64252,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63579,8 +64332,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63658,8 +64412,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63737,8 +64492,9 @@
             "issue": "Code duplication: 21.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63895,8 +64651,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63974,8 +64731,9 @@
             "issue": "Code duplication: 18.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64053,8 +64811,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64132,8 +64891,9 @@
             "issue": "Code duplication: 20.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64290,8 +65050,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64369,8 +65130,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64464,8 +65226,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64559,8 +65322,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64616,7 +65380,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.73189,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2153.rs",
@@ -64646,8 +65410,9 @@
             "issue": "High cognitive complexity: 30"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64703,7 +65468,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2154.rs",
@@ -64883,8 +65648,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64962,8 +65728,9 @@
             "issue": "Code duplication: 21.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65136,8 +65903,9 @@
             "issue": "Code duplication: 15.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65215,8 +65983,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65294,8 +66063,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65373,8 +66143,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65452,8 +66223,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65531,8 +66303,9 @@
             "issue": "Code duplication: 16.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65610,8 +66383,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65689,8 +66463,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65768,8 +66543,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65825,7 +66601,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2167.rs",
@@ -65896,7 +66672,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2168.rs",
@@ -65918,8 +66694,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66054,7 +66831,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.27143,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2170.rs",
@@ -66092,8 +66869,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66179,8 +66957,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66236,7 +67015,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.19763,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2172.rs",
@@ -66416,8 +67195,9 @@
             "issue": "Code duplication: 18.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66473,7 +67253,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2175.rs",
@@ -66566,8 +67346,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66623,7 +67404,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2177.rs",
@@ -66694,7 +67475,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2178.rs",
@@ -66724,8 +67505,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66803,8 +67585,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66882,8 +67665,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66961,8 +67745,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67040,8 +67825,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67097,7 +67883,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2183.rs",
@@ -67111,8 +67897,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67168,7 +67955,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2184.rs",
@@ -67239,7 +68026,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2185.rs",
@@ -67310,7 +68097,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2186.rs",
@@ -67324,8 +68111,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67381,7 +68169,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2187.rs",
@@ -67474,8 +68262,9 @@
             "issue": "Code duplication: 14.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67531,7 +68320,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2189.rs",
@@ -67632,8 +68421,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67711,8 +68501,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67768,7 +68559,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2192.rs",
@@ -67839,7 +68630,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2193.rs",
@@ -67932,8 +68723,9 @@
             "issue": "Code duplication: 13.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67989,7 +68781,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2195.rs",
@@ -68082,8 +68874,9 @@
             "issue": "Code duplication: 23.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68139,7 +68932,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2197.rs",
@@ -68240,8 +69033,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68297,7 +69091,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.41818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2199.rs",
@@ -68327,8 +69121,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68406,8 +69201,9 @@
             "issue": "Code duplication: 18.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68493,8 +69289,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68550,7 +69347,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2202.rs",
@@ -68621,7 +69418,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2203.rs",
@@ -68635,8 +69432,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68692,7 +69490,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2204.rs",
@@ -68706,8 +69504,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68763,7 +69562,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2205.rs",
@@ -68856,8 +69655,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68935,8 +69735,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69014,8 +69815,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69071,7 +69873,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.88319,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2209.rs",
@@ -69101,8 +69903,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69180,8 +69983,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69259,8 +70063,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69338,8 +70143,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69474,7 +70280,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.54677,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2214.rs",
@@ -69654,8 +70460,9 @@
             "issue": "Code duplication: 18.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69733,8 +70540,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69891,8 +70699,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70207,8 +71016,9 @@
             "issue": "Code duplication: 18.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70286,8 +71096,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70365,8 +71176,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70523,8 +71335,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70760,8 +71573,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70839,8 +71653,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70997,8 +71812,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71076,8 +71892,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71155,8 +71972,9 @@
             "issue": "Code duplication: 19.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71234,8 +72052,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71392,8 +72211,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71874,8 +72694,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71953,8 +72774,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72089,7 +72911,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.74,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2247.rs",
@@ -72119,8 +72941,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72198,8 +73021,9 @@
             "issue": "Code duplication: 18.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72571,7 +73395,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2253.rs",
@@ -72642,7 +73466,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2254.rs",
@@ -72713,7 +73537,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2255.rs",
@@ -72784,7 +73608,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2256.rs",
@@ -72798,8 +73622,9 @@
             "issue": "Found 2 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72855,7 +73680,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2257.rs",
@@ -72926,7 +73751,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2258.rs",
@@ -72997,7 +73822,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2259.rs",
@@ -73011,8 +73836,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73068,7 +73894,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2260.rs",
@@ -73139,7 +73965,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2261.rs",
@@ -73210,7 +74036,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2262.rs",
@@ -73281,7 +74107,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2263.rs",
@@ -73352,7 +74178,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2264.rs",
@@ -73423,7 +74249,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2265.rs",
@@ -73437,8 +74263,9 @@
             "issue": "Found 2 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73494,7 +74321,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2266.rs",
@@ -73508,8 +74335,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73565,7 +74393,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2267.rs",
@@ -73579,8 +74407,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73636,7 +74465,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2268.rs",
@@ -73650,8 +74479,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73707,7 +74537,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2269.rs",
@@ -73721,8 +74551,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73778,7 +74609,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2270.rs",
@@ -73792,8 +74623,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73849,7 +74681,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2271.rs",
@@ -73920,7 +74752,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2272.rs",
@@ -73934,8 +74766,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73991,7 +74824,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2273.rs",
@@ -74005,8 +74838,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74062,7 +74896,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2274.rs",
@@ -74076,8 +74910,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74133,7 +74968,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2275.rs",
@@ -74147,8 +74982,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74204,7 +75040,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2276.rs",
@@ -74218,8 +75054,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74275,7 +75112,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2277.rs",
@@ -74289,8 +75126,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74346,7 +75184,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2278.rs",
@@ -74360,8 +75198,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74417,7 +75256,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2279.rs",
@@ -74431,8 +75270,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74488,7 +75328,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2280.rs",
@@ -74502,8 +75342,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74581,8 +75422,9 @@
             "issue": "Code duplication: 13.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74638,7 +75480,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2282.rs",
@@ -74652,8 +75494,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74709,7 +75552,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2283.rs",
@@ -74723,8 +75566,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74780,7 +75624,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2284.rs",
@@ -74794,8 +75638,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74851,7 +75696,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2285.rs",
@@ -74865,8 +75710,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74922,7 +75768,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2286.rs",
@@ -74936,8 +75782,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74993,7 +75840,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2287.rs",
@@ -75007,8 +75854,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75064,7 +75912,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2288.rs",
@@ -75078,8 +75926,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75135,7 +75984,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2289.rs",
@@ -75149,8 +75998,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75206,7 +76056,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2290.rs",
@@ -75220,8 +76070,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75277,7 +76128,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2291.rs",
@@ -75291,8 +76142,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75348,7 +76200,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2292.rs",
@@ -75362,8 +76214,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75419,7 +76272,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2293.rs",
@@ -75433,8 +76286,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75490,7 +76344,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2294.rs",
@@ -75504,8 +76358,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75561,7 +76416,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2295.rs",
@@ -75575,8 +76430,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75632,7 +76488,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2296.rs",
@@ -75646,8 +76502,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75703,7 +76560,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2297.rs",
@@ -75717,8 +76574,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75774,7 +76632,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2298.rs",
@@ -75788,8 +76646,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75845,7 +76704,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.1235,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2299.rs",
@@ -75867,8 +76726,9 @@
             "issue": "Code duplication: 11.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75924,7 +76784,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2300.rs",
@@ -75938,8 +76798,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75995,7 +76856,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2301.rs",
@@ -76009,8 +76870,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76066,7 +76928,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2302.rs",
@@ -76080,8 +76942,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76137,7 +77000,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2303.rs",
@@ -76151,8 +77014,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76208,7 +77072,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2304.rs",
@@ -76222,8 +77086,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76279,7 +77144,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2305.rs",
@@ -76293,8 +77158,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76350,7 +77216,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2306.rs",
@@ -76364,8 +77230,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76421,7 +77288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2307.rs",
@@ -76435,8 +77302,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76514,8 +77382,9 @@
             "issue": "Code duplication: 12.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76571,7 +77440,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2309.rs",
@@ -76585,8 +77454,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76642,7 +77512,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2310.rs",
@@ -76656,8 +77526,9 @@
             "issue": "Found 15 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76713,7 +77584,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2311.rs",
@@ -76727,8 +77598,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76784,7 +77656,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 96.4792,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2312.rs",
@@ -76863,7 +77735,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2313.rs",
@@ -76877,8 +77749,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76934,7 +77807,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2314.rs",
@@ -76948,8 +77821,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77005,7 +77879,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2315.rs",
@@ -77019,8 +77893,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77076,7 +77951,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2316.rs",
@@ -77090,8 +77965,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77147,7 +78023,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.15738,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2317.rs",
@@ -77177,8 +78053,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77234,7 +78111,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2318.rs",
@@ -77248,8 +78125,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77327,8 +78205,9 @@
             "issue": "Code duplication: 13.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77384,7 +78263,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2320.rs",
@@ -77398,8 +78277,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77455,7 +78335,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2321.rs",
@@ -77469,8 +78349,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77526,7 +78407,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2322.rs",
@@ -77540,8 +78421,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77597,7 +78479,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2323.rs",
@@ -77611,8 +78493,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77668,7 +78551,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2324.rs",
@@ -77682,8 +78565,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77739,7 +78623,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2325.rs",
@@ -77753,8 +78637,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77889,7 +78774,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.3486,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec002.rs",
@@ -77976,7 +78861,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.28174,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec003.rs",
@@ -78063,7 +78948,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.03333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec004.rs",
@@ -78403,7 +79288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.23054,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec008.rs",
@@ -78569,7 +79454,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec010.rs",
@@ -78686,8 +79571,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -78838,7 +79724,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.78641,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec012.rs",
@@ -79233,7 +80119,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec017.rs",
@@ -79328,7 +80214,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.15745,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec018.rs",
@@ -79366,8 +80252,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -79423,7 +80310,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 96.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec019.rs",
@@ -79668,7 +80555,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 99.72273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec022.rs",
@@ -80079,7 +80966,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.19225,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/systemd001.rs",
@@ -80348,7 +81235,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.891304,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/suppression.rs",
@@ -80443,7 +81330,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/tests.rs",
@@ -80672,7 +81559,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.856606,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/error.rs",
@@ -80765,9 +81652,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/error_part2_incl2.rs",
@@ -80829,7 +81716,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.35715,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/generators.rs",
@@ -80940,7 +81827,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/lexer.rs",
@@ -81002,7 +81889,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/mod.rs",
@@ -81073,7 +81960,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser.rs",
@@ -81152,7 +82039,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.592514,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser_parse.rs",
@@ -81198,8 +82085,9 @@
             "issue": "High cyclomatic complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -81253,9 +82141,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser_part2_incl2.rs",
@@ -81499,7 +82387,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.37508,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/mod.rs",
@@ -81586,7 +82474,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.77907,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/parallel_safety.rs",
@@ -81689,7 +82577,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.7812,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/performance.rs",
@@ -81776,7 +82664,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.1573,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/portability.rs",
@@ -81942,7 +82830,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.2209,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/reproducible_builds.rs",
@@ -82108,7 +82996,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/semantic.rs",
@@ -82185,9 +83073,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/semantic_part2_incl2.rs",
@@ -82328,7 +83216,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/tests/mod.rs",
@@ -82390,7 +83278,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/config.rs",
@@ -82461,7 +83349,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/diagnostic.rs",
@@ -82556,7 +83444,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/error.rs",
@@ -82618,7 +83506,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/mod.rs",
@@ -82680,7 +83568,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.64562,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/cfg.rs",
@@ -82949,7 +83837,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gate_summary.rs",
@@ -83123,7 +84011,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_default_gatesummary.rs",
@@ -83183,9 +84071,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_part2_incl2.rs",
@@ -83245,9 +84133,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_part3_incl2.rs",
@@ -83309,7 +84197,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/lint_report.rs",
@@ -83380,7 +84268,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/lint_report_sbfl.rs",
@@ -83467,7 +84355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/mock_executor.rs",
@@ -83538,7 +84426,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/mod.rs",
@@ -83686,9 +84574,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/oracle_part2_incl2.rs",
@@ -83748,9 +84636,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/oracle_part3_incl2.rs",
@@ -83978,7 +84866,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/ast_display.rs",
@@ -84134,9 +85022,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/breakpoint_part2_incl2.rs",
@@ -84443,7 +85331,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/debugger_continueresult.rs",
@@ -84821,7 +85709,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/errors.rs",
@@ -84971,7 +85859,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/explain.rs",
@@ -85050,7 +85938,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/help.rs",
@@ -85121,7 +86009,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.21863,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/highlighting.rs",
@@ -85214,9 +86102,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/highlighting_part2_incl2.rs",
@@ -85278,7 +86166,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/linter.rs",
@@ -85640,9 +86528,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/logic_part2_incl2.rs",
@@ -85791,7 +86679,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/mod.rs",
@@ -85862,7 +86750,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/modes.rs",
@@ -86099,7 +86987,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.32628,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier.rs",
@@ -86186,7 +87074,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier_transforms.rs",
@@ -86257,7 +87145,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.9,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier_transforms_gen.rs",
@@ -86336,7 +87224,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/state.rs",
@@ -86407,7 +87295,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/state_cont.rs",
@@ -86548,7 +87436,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/mod.rs",
@@ -86627,7 +87515,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 83.1,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser.rs",
@@ -86714,7 +87602,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.3,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_convert.rs",
@@ -86801,7 +87689,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.9,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_convert_2.rs",
@@ -86967,7 +87855,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.720215,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests3.rs",
@@ -87062,7 +87950,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.94832,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests4.rs",
@@ -87157,7 +88045,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.61255,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests5.rs",
@@ -87236,7 +88124,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.71154,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests5_counter.rs",
@@ -87313,9 +88201,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_part2_incl2.rs",
@@ -87377,7 +88265,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.6,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_string.rs",
@@ -87464,7 +88352,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.79876,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/tests.rs",
@@ -87543,7 +88431,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/stdlib.rs",
@@ -87772,7 +88660,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/test_generator/coverage.rs",
@@ -87938,7 +88826,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/test_generator/mod.rs",
@@ -88087,7 +88975,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.8,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/boundary.rs",
@@ -88174,7 +89062,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/coverage.rs",
@@ -88245,7 +89133,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/cross_validation.rs",
@@ -88316,7 +89204,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.03226,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/error_injection.rs",
@@ -88354,8 +89242,9 @@
             "issue": "High cyclomatic complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -88490,7 +89379,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.46477,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/stress.rs",
@@ -88520,8 +89409,9 @@
             "issue": "High cognitive complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -88577,7 +89467,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/buffer.rs",
@@ -88648,7 +89538,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.74419,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/events.rs",
@@ -88814,7 +89704,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/mod.rs",
@@ -89034,7 +89924,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.7,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/app.rs",
@@ -89121,7 +90011,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/events.rs",
@@ -89192,7 +90082,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 95.818184,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/mod.rs",
@@ -89271,7 +90161,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/panels.rs",
@@ -89421,7 +90311,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/types/mod.rs",
@@ -89562,7 +90452,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/mod.rs",
@@ -89633,7 +90523,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/pipeline.rs",
@@ -89894,7 +90784,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.57445,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/rules.rs",
@@ -90060,7 +90950,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/kani_harnesses.rs",
@@ -90131,7 +91021,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/mod.rs",
@@ -90202,7 +91092,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.7,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/properties.rs",
@@ -90289,7 +91179,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.46154,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/tests.rs",
@@ -90534,7 +91424,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.645485,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_dockerfile_integration.rs",
@@ -90613,7 +91503,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.82869,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_dockerfile_purify.rs",
@@ -90692,7 +91582,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.811325,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_integration.rs",
@@ -90771,7 +91661,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.67316,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_make_formatting.rs",
@@ -90850,7 +91740,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.96403,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_make_lint.rs",
@@ -91008,7 +91898,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.81967,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/falsification_probar_testing.rs",
@@ -91095,7 +91985,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/golden_trace.rs",
@@ -91245,7 +92135,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.71544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/linter_bug_hunting.rs",
@@ -91498,7 +92388,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/linter_tui_bug_hunting_hunt.rs",
@@ -91569,7 +92459,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.7541,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/makefile_false_positives_fix.rs",
@@ -91885,7 +92775,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/parse_performance.rs",
@@ -92043,7 +92933,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.70348,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/parser_probar_testing.rs",
@@ -92209,7 +93099,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.292595,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/property_dockerfile_purify.rs",
@@ -92296,7 +93186,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.51958,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/property_fix_safety.rs",
@@ -92533,7 +93423,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.864334,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/simulation_probar_testing.rs",
@@ -92620,7 +93510,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.608696,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/stdlib_extended_test.rs",
@@ -92857,7 +93747,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.26165,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_fix_safety_taxonomy.rs",
@@ -93094,7 +93984,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_005_lint_integration.rs",
@@ -93244,7 +94134,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.8125,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_010_dockerfile_scoring.rs",
@@ -93323,7 +94213,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.34599,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_016_makefile_false_positives.rs",
@@ -93402,7 +94292,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_003_002_cli.rs",
@@ -93552,7 +94442,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_explain_mode.rs",
@@ -93623,7 +94513,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.28926,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_mode_based_processing.rs",
@@ -94018,7 +94908,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.975746,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/transpiler_bug_hunting.rs",
@@ -94348,9 +95238,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/generated_contracts.rs",
@@ -94586,7 +95476,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/handlers/mod.rs",
@@ -94727,7 +95617,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/main.rs",
@@ -94798,7 +95688,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/build.rs",
@@ -94875,9 +95765,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/src/generated_contracts.rs",
@@ -94939,7 +95829,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/src/lib.rs",
@@ -95001,7 +95891,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 66.92609,
-        "grade": "CPlus",
+        "grade": "C+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./scripts/split_registry.py",
@@ -95112,7 +96002,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.16867,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/generated_contracts.rs",
@@ -95191,7 +96081,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/lib.rs",
@@ -95253,7 +96143,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/verification_specs.rs",
@@ -95403,7 +96293,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/sandbox.rs",
@@ -95474,7 +96364,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.994354,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/shellcheck_validation.rs",
@@ -95553,7 +96443,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/simple.rs",
@@ -95703,7 +96593,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_create.rs",
@@ -95774,7 +96664,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_get.rs",
@@ -95845,7 +96735,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_setup.rs",
@@ -95916,7 +96806,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/python_project_bootstrap_more.rs",
@@ -96223,7 +97113,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 83.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/canary_pytorch.py",
@@ -96326,7 +97216,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 84.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/eval_canary.py",
@@ -96413,7 +97303,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 87.93909,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/evaluate_chat.py",
@@ -96624,19 +97514,19 @@
     }
   },
   "summary": {
-    "total_files": 1229,
-    "avg_score": 95.05844,
+    "total_files": 1236,
+    "avg_score": 95.03838,
     "grade_distribution": {
-      "APlus": 635,
-      "A": 517,
-      "AMinus": 33,
-      "BPlus": 32,
+      "A+": 636,
+      "A": 523,
+      "A-": 33,
+      "B+": 32,
       "B": 11,
-      "CPlus": 1
+      "C+": 1
     },
     "languages": {
       "Python": 7,
-      "Rust": 1221,
+      "Rust": 1228,
       "TypeScript": 1
     }
   }

--- a/bashrs-oracle/src/lib_tests_oracle_creat.rs
+++ b/bashrs-oracle/src/lib_tests_oracle_creat.rs
@@ -1,7 +1,13 @@
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
-    use super::*;
+    // `crate::*`, not `super::*`: this file is pulled in by lib_cont.rs via
+    // `#[path = "lib_tests_oracle_creat.rs"] mod tests_extracted;`, so `super`
+    // is lib_cont — not the crate root where Oracle/ErrorCategory/Corpus/
+    // OracleConfig/ErrorFeatures/DriftStatus actually live. PMAT-229 renamed
+    // the file into that submodule and `super::*` quietly stopped reaching
+    // them; nothing built this member, so it stayed broken. See GH-214.
+    use crate::*;
 
     #[test]
     fn test_oracle_creation() {


### PR DESCRIPTION
Closes #214.

`bashrs-oracle`'s test module has not compiled since **PMAT-229** (`b2debf1710`).

`lib_cont.rs` pulls the file in with `#[path = "lib_tests_oracle_creat.rs"] mod tests_extracted;`, so inside it `super` is **`lib_cont`** — not the crate root, where the types actually live. That refactor renamed the file into the submodule and `use super::*` quietly stopped reaching any of them.

Six types, not the two the issue recorded: `Oracle`, `ErrorCategory`, `Corpus`, `OracleConfig`, `ErrorFeatures`, `DriftStatus`.

## Why it survived months of green

Nothing in the pipeline built this workspace member:

- CI's reusable `sovereign-ci` workflow defaults to `--lib`, which scopes to the **root package** (`bashrs-specs`)
- the infra clean-room gate ran `cargo test --lib` at the **workspace root** — same blind spot (paiml/infra#170)

It surfaced only when that gate was fixed to test the crate it gates, at which point B2 failed on the first honest run.

## Verification

| | |
|---|---|
| RED on `origin/main` | `cargo test -p bashrs-oracle --lib --no-run` → **19 × E0433** |
| GREEN with this fix | **48 passed, 0 failed** |

That includes the 6 `tests_extracted::tests::*` tests which had not been compiled, let alone run, since February.

## Follow-up in this PR

A second commit adds `test_workspace: true` to `ci.yml` so a workspace member cannot rot invisibly again — **pending** a local `cargo test --workspace --lib --no-run` proving every member builds in that scope. I won't flip it on an assumption; turning your CI red would be a worse outcome than the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)