### PR TITLE
fix(lint): five false positives that made users disable bashrs lint (GH-217, GH-209)

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.29.0",
-  "created_at": "2026-08-10T07:08:19.394754126Z",
+  "version": "3.30.0",
+  "created_at": "2026-08-11T18:07:12.916864083Z",
   "git_context": null,
   "files": {
     "./bashrs-oracle/benches/classification.rs": {
@@ -47,7 +47,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/benches/classification.rs",
@@ -284,7 +284,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/corpus.rs",
@@ -355,7 +355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 80.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/features.rs",
@@ -440,9 +440,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/generated_contracts.rs",
@@ -504,7 +504,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/lib.rs",
@@ -575,7 +575,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-oracle/src/lib_cont.rs",
@@ -637,7 +637,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-wasm/src/generated_contracts.rs",
@@ -699,7 +699,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.08572,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./bashrs-wasm/src/lib.rs",
@@ -952,7 +952,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./benches/workspace_bench.rs",
@@ -1023,7 +1023,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 0.9,
         "language": "TypeScript",
         "file_path": "./editors/vscode/src/extension.ts",
@@ -1102,7 +1102,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/backup-clean.rs",
@@ -1173,7 +1173,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/backup-script.rs",
@@ -1244,7 +1244,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic/functions.rs",
@@ -1315,7 +1315,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic/variables.rs",
@@ -1386,7 +1386,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/basic.rs",
@@ -1457,7 +1457,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/build-automation.rs",
@@ -1528,7 +1528,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex01_basic_string.rs",
@@ -1590,7 +1590,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex02_integer_variables.rs",
@@ -1652,7 +1652,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex03_boolean_variables.rs",
@@ -1714,7 +1714,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex04_mixed_types.rs",
@@ -1776,7 +1776,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex05_special_chars.rs",
@@ -1838,7 +1838,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex06_path_variables.rs",
@@ -1900,7 +1900,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex07_paths_with_spaces.rs",
@@ -1962,7 +1962,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex08_configuration.rs",
@@ -2024,7 +2024,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex09_naming_conventions.rs",
@@ -2086,7 +2086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch02_variables/ex10_unicode.rs",
@@ -2148,7 +2148,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex01_basic_function.rs",
@@ -2219,7 +2219,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex02_one_parameter.rs",
@@ -2290,7 +2290,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex03_multiple_params.rs",
@@ -2361,7 +2361,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex04_mixed_types.rs",
@@ -2432,7 +2432,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex05_function_composition.rs",
@@ -2503,7 +2503,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex06_helper_functions.rs",
@@ -2574,7 +2574,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex07_nested_calls.rs",
@@ -2645,7 +2645,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex08_installer_pattern.rs",
@@ -2716,7 +2716,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex09_many_parameters.rs",
@@ -2795,7 +2795,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex10_parameter_naming.rs",
@@ -2866,7 +2866,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex11_variadic_pattern.rs",
@@ -2937,7 +2937,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch03_functions/ex12_two_stage_deployment.rs",
@@ -3008,7 +3008,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex01_basic_if.rs",
@@ -3079,7 +3079,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex02_if_else.rs",
@@ -3150,7 +3150,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex03_if_elif_else.rs",
@@ -3221,7 +3221,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex04_integer_comparisons.rs",
@@ -3292,7 +3292,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex05_string_comparison.rs",
@@ -3363,7 +3363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex06_logical_and.rs",
@@ -3434,7 +3434,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex07_logical_or.rs",
@@ -3505,7 +3505,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex08_not_operator.rs",
@@ -3576,7 +3576,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex09_nested_if.rs",
@@ -3647,7 +3647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex10_conditional_calls.rs",
@@ -3718,7 +3718,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex11_early_return.rs",
@@ -3789,7 +3789,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex12_guard_clauses.rs",
@@ -3860,7 +3860,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex13_complex_logic.rs",
@@ -3931,7 +3931,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex14_boolean_variables.rs",
@@ -4002,7 +4002,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/ch04_control_flow/ex15_installer_logic.rs",
@@ -4073,7 +4073,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/conditional-logic.rs",
@@ -4144,7 +4144,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/config-manager.rs",
@@ -4215,7 +4215,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/control_flow/conditionals.rs",
@@ -4286,7 +4286,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 98.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/control_flow/loops.rs",
@@ -4365,7 +4365,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/download-install.rs",
@@ -4436,7 +4436,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/environment-setup.rs",
@@ -4507,7 +4507,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/error-handling.rs",
@@ -4578,7 +4578,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/factorial.rs",
@@ -4649,7 +4649,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/file-operations.rs",
@@ -4720,7 +4720,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/hello.rs",
@@ -4791,7 +4791,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/installer.rs",
@@ -4862,7 +4862,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/minimal.rs",
@@ -4933,7 +4933,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/node-installer.rs",
@@ -5004,7 +5004,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/package-manager.rs",
@@ -5075,7 +5075,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/rust-installer.rs",
@@ -5146,7 +5146,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/safety/escaping.rs",
@@ -5217,7 +5217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/safety/injection_prevention.rs",
@@ -5288,7 +5288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/simple.rs",
@@ -5359,7 +5359,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/stdlib_demo.rs",
@@ -5430,7 +5430,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/system-info.rs",
@@ -5501,7 +5501,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/user-functions.rs",
@@ -5572,7 +5572,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./examples/xtask_integration/hooks/pre-commit.rs",
@@ -5643,7 +5643,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./fuzz/fuzz_targets/injection_detection.rs",
@@ -5714,7 +5714,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./fuzz/fuzz_targets/transpile_robustness.rs",
@@ -5776,7 +5776,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.31638,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/bash_purification_benchmarks.rs",
@@ -5855,7 +5855,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.89313,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/fix_safety_bench.rs",
@@ -5934,7 +5934,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/lint_performance.rs",
@@ -6005,7 +6005,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/make_parsing_bench.rs",
@@ -6155,7 +6155,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.33333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/makefile_benchmarks.rs",
@@ -6234,7 +6234,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.368935,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/benches/tracing_overhead.rs",
@@ -6637,7 +6637,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/baselines.rs",
@@ -6708,7 +6708,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/contract_validation.rs",
@@ -6779,7 +6779,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/conversation_generator.rs",
@@ -6850,7 +6850,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/cwe_mapping_demo.rs",
@@ -6921,7 +6921,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/evaluation_metrics.rs",
@@ -7079,7 +7079,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/fast_classify_export.rs",
@@ -7229,7 +7229,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/label_audit.rs",
@@ -7379,7 +7379,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.67742,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/optimizer_benchmark.rs",
@@ -7458,7 +7458,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.67273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/quality_tools_demo.rs",
@@ -7545,7 +7545,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/safety_check.rs",
@@ -7616,7 +7616,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/shell_safety_classifier.rs",
@@ -7687,7 +7687,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/shellsafetybench.rs",
@@ -7758,7 +7758,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_data_pipeline.rs",
@@ -7829,7 +7829,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_report.rs",
@@ -7891,7 +7891,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/ssc_workflow.rs",
@@ -7962,7 +7962,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/examples/tokenizer_validation.rs",
@@ -8191,7 +8191,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 96.948044,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/mod.rs",
@@ -8270,7 +8270,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.379486,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted.rs",
@@ -8363,9 +8363,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted_part2_incl2.rs",
@@ -8427,7 +8427,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 83.55068,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/restricted_restrictedast.rs",
@@ -8601,7 +8601,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.073975,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ast/visitor.rs",
@@ -8688,7 +8688,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.55769,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/analysis_report.rs",
@@ -8767,7 +8767,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.232025,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast.rs",
@@ -8854,7 +8854,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.25325,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast_bashast.rs",
@@ -8939,9 +8939,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/ast_part2_incl2.rs",
@@ -9003,7 +9003,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/codegen.rs",
@@ -9074,7 +9074,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/generators.rs",
@@ -9145,7 +9145,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/lexer.rs",
@@ -9778,7 +9778,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.19825,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/parser_control.rs",
@@ -10039,7 +10039,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.63125,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/parser_expr.rs",
@@ -10229,7 +10229,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic.rs",
@@ -10395,7 +10395,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_default.rs",
@@ -10464,9 +10464,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_part2_incl2.rs",
@@ -10526,9 +10526,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/semantic_part3_incl2.rs",
@@ -10590,7 +10590,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/mod.rs",
@@ -10652,7 +10652,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.09877,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_expansion.rs",
@@ -10731,7 +10731,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.89285,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_prefix.rs",
@@ -10810,7 +10810,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.328766,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part1_prop_string.rs",
@@ -11752,17 +11752,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 15.471698,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 91.337906,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part2_s3.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 11 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.528302,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 22.6%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -12610,7 +12627,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_6.rs",
@@ -13234,7 +13251,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_s6.rs",
@@ -13378,17 +13395,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 17.09091,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 92.80992,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part3_s8.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 35 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 2.9090908,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 14.5%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -13683,7 +13717,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_4.rs",
@@ -13754,7 +13788,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_5.rs",
@@ -13904,7 +13938,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_7.rs",
@@ -13975,7 +14009,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_8.rs",
@@ -14283,7 +14317,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s4.rs",
@@ -14354,7 +14388,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s5.rs",
@@ -14504,7 +14538,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s7.rs",
@@ -14575,7 +14609,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part4_s8.rs",
@@ -14719,17 +14753,34 @@
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 20.0,
+        "duplication_ratio": 16.923077,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 6.5,
+        "total": 94.02098,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_10.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0769231,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.4%"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -14787,7 +14838,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_2.rs",
@@ -14858,7 +14909,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_3.rs",
@@ -14927,13 +14978,22 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
-        "total": 100.0,
-        "grade": "APlus",
+        "entropy_score": 5.0,
+        "total": 95.454544,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_4.rs",
-        "penalties_applied": [],
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 19 duplicate code patterns"
+          }
+        ],
         "critical_defects_count": 0,
         "has_critical_defects": false,
         "has_contract_coverage": false
@@ -15149,7 +15209,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.2943,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_7.rs",
@@ -15228,7 +15288,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17418,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_8.rs",
@@ -15307,7 +15367,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.9199,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_9.rs",
@@ -15386,7 +15446,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_d.rs",
@@ -15536,7 +15596,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s2.rs",
@@ -15607,7 +15667,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s3.rs",
@@ -15678,7 +15738,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s4.rs",
@@ -15907,7 +15967,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.2943,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s7.rs",
@@ -15986,7 +16046,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17418,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s8.rs",
@@ -16065,7 +16125,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.9199,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_parser/tests/part5_s9.rs",
@@ -16239,7 +16299,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.059525,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/coverage/mod_branchinfo.rs",
@@ -16340,9 +16400,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/coverage/mod_part2_incl2.rs",
@@ -16404,7 +16464,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_score.rs",
@@ -16499,7 +16559,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_scoring.rs",
@@ -16592,9 +16652,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/dockerfile_scoring_part2_incl2.rs",
@@ -16656,7 +16716,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.08418,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter.rs",
@@ -16830,7 +16890,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_expr.rs",
@@ -16909,7 +16969,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.801025,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_formatter.rs",
@@ -17002,9 +17062,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_part2_incl2.rs",
@@ -17064,9 +17124,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/formatter_part3_incl2.rs",
@@ -17128,7 +17188,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/linter/mod.rs",
@@ -17190,7 +17250,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/linter/suppressions.rs",
@@ -17261,7 +17321,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/mod.rs",
@@ -17323,7 +17383,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/scoring/mod.rs",
@@ -17410,7 +17470,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_quality/scoring_config.rs",
@@ -17568,7 +17628,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen.rs",
@@ -17637,9 +17697,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen_part2_incl2.rs",
@@ -17699,9 +17759,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/codegen_part3_incl2.rs",
@@ -17858,7 +17918,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/mod.rs",
@@ -17929,7 +17989,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/patterns.rs",
@@ -18079,7 +18139,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/conditional_exprs.rs",
@@ -18237,7 +18297,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/expressions.rs",
@@ -18316,7 +18376,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/mod.rs",
@@ -18387,7 +18447,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.46032,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/purification/tests.rs",
@@ -18466,7 +18526,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/test_generator.rs",
@@ -18616,7 +18676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/type_check.rs",
@@ -18687,7 +18747,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bash_transpiler/type_check_default.rs",
@@ -18758,7 +18818,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/bashrs.rs",
@@ -18829,7 +18889,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/quality-dashboard.rs",
@@ -18900,7 +18960,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/bin/quality-gate.rs",
@@ -19137,7 +19197,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/adversarial_commands.rs",
@@ -19216,7 +19276,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60564,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args.rs",
@@ -19253,68 +19313,68 @@
     },
     "./rash/src/cli/args_corpus.rs": {
       "content_hash": [
-        28,
-        163,
-        120,
-        46,
-        131,
-        86,
-        161,
-        63,
-        171,
-        216,
-        154,
-        99,
-        168,
-        255,
-        118,
-        236,
-        249,
-        122,
-        41,
-        51,
-        59,
-        92,
-        109,
-        255,
-        93,
-        141,
-        122,
+        202,
         90,
-        84,
-        150,
-        3,
-        107
+        239,
+        103,
+        182,
+        83,
+        58,
+        52,
+        5,
+        168,
+        66,
+        236,
+        83,
+        167,
+        199,
+        162,
+        159,
+        146,
+        206,
+        204,
+        87,
+        28,
+        183,
+        31,
+        236,
+        50,
+        108,
+        156,
+        28,
+        74,
+        50,
+        137
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 12.639999,
+        "duplication_ratio": 16.666666,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 97.64,
-        "grade": "APlus",
+        "entropy_score": 9.5,
+        "total": 96.51515,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_corpus.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 5.0,
+            "amount": 0.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 18 duplicate code patterns"
+            "issue": "Found 1 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 7.36,
+            "amount": 3.3333335,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 36.8%"
+            "issue": "Code duplication: 16.7%"
           }
         ],
         "critical_defects_count": 0,
@@ -19332,52 +19392,281 @@
     },
     "./rash/src/cli/args_corpus_analysis.rs": {
       "content_hash": [
-        104,
-        98,
-        107,
-        18,
-        24,
-        250,
-        244,
-        124,
-        204,
+        236,
         29,
-        239,
-        112,
-        211,
-        132,
-        133,
-        102,
-        33,
-        119,
-        20,
-        252,
-        26,
-        6,
-        104,
-        74,
-        176,
-        178,
-        43,
-        0,
-        89,
-        135,
+        83,
+        159,
+        92,
         123,
-        81
+        243,
+        4,
+        219,
+        117,
+        31,
+        28,
+        15,
+        144,
+        127,
+        229,
+        60,
+        36,
+        176,
+        103,
+        164,
+        44,
+        84,
+        103,
+        78,
+        221,
+        147,
+        203,
+        217,
+        159,
+        57,
+        204
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 12.890625,
+        "duplication_ratio": 16.923077,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 96.74826,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0769231,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 15.4%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_diag.rs": {
+      "content_hash": [
+        131,
+        108,
+        33,
+        17,
+        163,
+        69,
+        31,
+        72,
+        202,
+        188,
+        191,
+        188,
+        191,
+        118,
+        179,
+        21,
+        249,
+        135,
+        140,
+        9,
+        11,
+        215,
+        141,
+        19,
+        243,
+        255,
+        96,
+        110,
+        252,
+        113,
+        166,
+        218
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.5,
+        "total": 97.72727,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis_diag.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 2.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 5 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_gates.rs": {
+      "content_hash": [
+        108,
+        236,
+        76,
+        105,
+        130,
+        54,
+        25,
+        169,
+        20,
+        21,
+        207,
+        246,
+        31,
+        135,
+        143,
+        115,
+        229,
+        229,
+        142,
+        39,
+        201,
+        170,
+        127,
+        226,
+        29,
+        199,
+        152,
+        161,
+        187,
+        48,
+        80,
+        124
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 16.666666,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 7.0,
+        "total": 94.242424,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_analysis_gates.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 6 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 3.3333335,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 16.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_analysis_pipeline.rs": {
+      "content_hash": [
+        30,
+        70,
+        248,
+        136,
+        26,
+        59,
+        82,
+        109,
+        122,
+        75,
+        238,
+        88,
+        249,
+        109,
+        18,
+        87,
+        159,
+        194,
+        14,
+        224,
+        200,
+        251,
+        248,
+        19,
+        102,
+        181,
+        113,
+        230,
+        60,
+        36,
+        89,
+        174
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 11.655629,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 97.890625,
-        "grade": "APlus",
+        "total": 96.655624,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
-        "file_path": "./rash/src/cli/args_corpus_analysis.rs",
+        "file_path": "./rash/src/cli/args_corpus_analysis_pipeline.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
@@ -19385,15 +19674,244 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 22 duplicate code patterns"
+            "issue": "Found 18 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 7.109375,
+            "amount": 8.344371,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 35.5%"
+            "issue": "Code duplication: 41.7%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_diagnostics.rs": {
+      "content_hash": [
+        129,
+        158,
+        58,
+        44,
+        25,
+        56,
+        215,
+        221,
+        124,
+        121,
+        131,
+        235,
+        177,
+        4,
+        96,
+        174,
+        10,
+        50,
+        141,
+        116,
+        177,
+        67,
+        176,
+        81,
+        30,
+        35,
+        113,
+        2,
+        194,
+        40,
+        243,
+        55
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 9.5,
+        "total": 99.545456,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_diagnostics.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 0.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 1 duplicate code patterns"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_operations.rs": {
+      "content_hash": [
+        198,
+        113,
+        31,
+        1,
+        176,
+        31,
+        182,
+        112,
+        205,
+        182,
+        153,
+        163,
+        104,
+        190,
+        129,
+        51,
+        249,
+        255,
+        43,
+        136,
+        27,
+        186,
+        121,
+        20,
+        63,
+        149,
+        200,
+        123,
+        172,
+        205,
+        32,
+        187
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 15.294117,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.5,
+        "total": 92.5401,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_operations.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 4.7058825,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 23.5%"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./rash/src/cli/args_corpus_scoring.rs": {
+      "content_hash": [
+        51,
+        199,
+        71,
+        240,
+        159,
+        183,
+        180,
+        60,
+        233,
+        206,
+        120,
+        201,
+        74,
+        168,
+        167,
+        185,
+        175,
+        239,
+        172,
+        111,
+        251,
+        207,
+        113,
+        218,
+        2,
+        173,
+        15,
+        146,
+        227,
+        115,
+        154,
+        235
+      ],
+      "score": {
+        "structural_complexity": 25.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 11.044776,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 96.04478,
+        "grade": "A+",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/args_corpus_scoring.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 12 duplicate code patterns"
+          },
+          {
+            "source_metric": "Duplication",
+            "amount": 8.955224,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Code duplication: 44.8%"
           }
         ],
         "critical_defects_count": 0,
@@ -19453,7 +19971,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.64285,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_ext.rs",
@@ -19532,7 +20050,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.916336,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/args_tools.rs",
@@ -19862,9 +20380,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_part2_incl2.rs",
@@ -19924,9 +20442,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_part3_incl2.rs",
@@ -20075,7 +20593,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.8,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/bench_verify.rs",
@@ -20154,7 +20672,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/cfg_commands.rs",
@@ -20225,7 +20743,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/chat_inference.rs",
@@ -20296,7 +20814,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/classify_commands.rs",
@@ -20391,7 +20909,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/color.rs",
@@ -20420,48 +20938,48 @@
     },
     "./rash/src/cli/commands.rs": {
       "content_hash": [
-        157,
-        97,
-        118,
-        38,
-        189,
-        116,
+        125,
+        82,
+        69,
+        115,
+        111,
         110,
-        110,
-        67,
-        85,
-        206,
-        253,
-        164,
-        166,
-        60,
-        245,
-        97,
-        255,
-        49,
-        167,
-        110,
-        140,
-        175,
-        162,
-        124,
-        15,
-        2,
-        134,
-        109,
+        168,
+        89,
+        139,
+        231,
+        204,
+        40,
+        72,
+        200,
+        179,
         47,
-        108,
-        251
+        102,
+        145,
+        28,
+        252,
+        197,
+        144,
+        120,
+        18,
+        194,
+        236,
+        90,
+        153,
+        22,
+        185,
+        154,
+        158
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.71605,
+        "duplication_ratio": 17.73006,
         "coupling_score": 12.8,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 91.37823,
+        "total": 91.39096,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -20477,11 +20995,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.2839506,
+            "amount": 2.2699385,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 11.4%"
+            "issue": "Code duplication: 11.3%"
           },
           {
             "source_metric": "Coupling",
@@ -20636,7 +21154,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.4,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/comply_commands.rs",
@@ -20731,7 +21249,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.27315,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/config_commands.rs",
@@ -20826,7 +21344,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.76363,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_advanced_commands.rs",
@@ -20964,6 +21482,85 @@
       },
       "git_context": null
     },
+    "./rash/src/cli/corpus_analysis_dispatch.rs": {
+      "content_hash": [
+        33,
+        215,
+        85,
+        88,
+        197,
+        211,
+        180,
+        97,
+        171,
+        157,
+        28,
+        25,
+        226,
+        8,
+        51,
+        213,
+        19,
+        38,
+        222,
+        89,
+        159,
+        199,
+        11,
+        181,
+        203,
+        224,
+        114,
+        95,
+        0,
+        36,
+        175,
+        44
+      ],
+      "score": {
+        "structural_complexity": 10.0,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 90.0,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/cli/corpus_analysis_dispatch.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 16 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 15.0,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cyclomatic complexity: 64"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
     "./rash/src/cli/corpus_b2_commands.rs": {
       "content_hash": [
         127,
@@ -21008,7 +21605,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_b2_commands.rs",
@@ -21103,7 +21700,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_b2_fix_commands.rs",
@@ -21198,7 +21795,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.82846,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_compare_commands.rs",
@@ -21301,7 +21898,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.11329,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands.rs",
@@ -21396,7 +21993,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_corpus.rs",
@@ -21546,7 +22143,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.18622,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_corpus_4.rs",
@@ -21639,9 +22236,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_config_commands_part2_incl2.rs",
@@ -21703,7 +22300,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.77246,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_convergence_commands.rs",
@@ -21764,38 +22361,38 @@
     },
     "./rash/src/cli/corpus_core_commands.rs": {
       "content_hash": [
-        171,
-        156,
-        48,
-        30,
-        39,
-        32,
-        67,
-        20,
-        161,
-        162,
-        189,
-        165,
-        121,
-        55,
-        15,
-        126,
-        118,
         183,
-        125,
-        147,
-        155,
-        113,
-        18,
+        106,
+        5,
+        52,
+        51,
+        141,
+        2,
         77,
-        194,
-        219,
-        148,
-        62,
-        88,
-        99,
-        62,
-        41
+        96,
+        74,
+        250,
+        118,
+        20,
+        8,
+        69,
+        116,
+        23,
+        60,
+        68,
+        243,
+        200,
+        95,
+        75,
+        154,
+        244,
+        90,
+        89,
+        199,
+        221,
+        217,
+        249,
+        91
       ],
       "score": {
         "structural_complexity": 10.0,
@@ -21804,8 +22401,8 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 90.0,
+        "entropy_score": 7.5,
+        "total": 92.5,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -21813,11 +22410,11 @@
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 5.0,
+            "amount": 2.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 19 duplicate code patterns"
+            "issue": "Found 5 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -21825,7 +22422,7 @@
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cyclomatic complexity: 152"
+            "issue": "High cyclomatic complexity: 87"
           }
         ],
         "critical_defects_count": 0,
@@ -21885,7 +22482,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60365,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_decision_commands.rs",
@@ -22225,7 +22822,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_entry_commands.rs",
@@ -22296,7 +22893,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_expansion_commands.rs",
@@ -22462,7 +23059,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.587006,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_gate_commands.rs",
@@ -22565,7 +23162,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.65,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_metrics_commands.rs",
@@ -22660,7 +23257,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.36757,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ml_commands.rs",
@@ -22834,7 +23431,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.18605,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_pipeline_commands.rs",
@@ -23000,7 +23597,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_report_commands.rs",
@@ -23087,7 +23684,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_score_print_commands.rs",
@@ -23261,7 +23858,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_corpus.rs",
@@ -23330,9 +23927,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_part2_incl2.rs",
@@ -23394,7 +23991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.89731,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_ssb_commands_toolcheck.rs",
@@ -23489,7 +24086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.35308,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_tier_commands.rs",
@@ -23576,7 +24173,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_time_commands.rs",
@@ -23671,7 +24268,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.73334,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_viz_commands.rs",
@@ -23766,7 +24363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.882355,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/corpus_weight_commands.rs",
@@ -23940,7 +24537,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/devcontainer_commands.rs",
@@ -24011,7 +24608,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_commands.rs",
@@ -24090,7 +24687,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.92157,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_profile_commands.rs",
@@ -24193,7 +24790,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.52307,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/dockerfile_validate_commands.rs",
@@ -24288,7 +24885,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/explain_command.rs",
@@ -24454,7 +25051,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/format_commands.rs",
@@ -24533,7 +25130,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/gate_commands.rs",
@@ -24620,7 +25217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_commands.rs",
@@ -24802,7 +25399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.407005,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_logic.rs",
@@ -24889,7 +25486,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.64138,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/installer_run_logic.rs",
@@ -24950,38 +25547,38 @@
     },
     "./rash/src/cli/lint_commands.rs": {
       "content_hash": [
-        56,
-        0,
-        90,
-        115,
-        0,
-        231,
-        154,
-        249,
-        100,
-        181,
-        169,
-        179,
-        254,
-        30,
+        178,
+        54,
+        91,
+        167,
+        192,
+        129,
         80,
-        0,
-        82,
-        116,
-        14,
-        118,
-        19,
-        90,
-        39,
-        179,
-        103,
-        147,
-        93,
-        203,
-        190,
-        65,
-        74,
-        33
+        64,
+        34,
+        228,
+        158,
+        250,
+        170,
+        207,
+        108,
+        89,
+        72,
+        75,
+        83,
+        49,
+        163,
+        143,
+        156,
+        133,
+        135,
+        27,
+        206,
+        34,
+        208,
+        192,
+        217,
+        17
       ],
       "score": {
         "structural_complexity": 5.0,
@@ -24992,7 +25589,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/lint_commands.rs",
@@ -25003,7 +25600,7 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 31 duplicate code patterns"
+            "issue": "Found 32 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -25079,7 +25676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic.rs",
@@ -25245,7 +25842,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.16892,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_format.rs",
@@ -25443,7 +26040,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_shell.rs",
@@ -25514,7 +26111,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 96.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/logic_validate.rs",
@@ -25646,38 +26243,38 @@
     },
     "./rash/src/cli/mod.rs": {
       "content_hash": [
+        51,
         59,
-        43,
-        27,
-        191,
-        49,
-        56,
-        140,
-        23,
-        139,
-        194,
-        167,
-        238,
-        149,
-        103,
-        234,
-        63,
-        242,
+        126,
+        253,
+        231,
+        0,
         99,
-        102,
-        153,
-        35,
-        18,
-        10,
-        24,
-        179,
-        149,
-        122,
-        220,
+        192,
+        173,
+        177,
+        71,
+        101,
+        127,
+        152,
+        29,
+        124,
+        116,
+        44,
+        70,
+        36,
+        1,
         150,
-        202,
-        146,
-        251
+        189,
+        250,
+        137,
+        120,
+        65,
+        37,
+        195,
+        227,
+        3,
+        235
       ],
       "score": {
         "structural_complexity": 25.0,
@@ -25688,7 +26285,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/mod.rs",
@@ -25924,7 +26521,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.49091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/property_commands.rs",
@@ -26177,7 +26774,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/score_commands.rs",
@@ -26620,7 +27217,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/cli/watch_commands.rs",
@@ -26723,7 +27320,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/loader.rs",
@@ -26794,7 +27391,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/mod.rs",
@@ -26944,7 +27541,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/compiler/tests.rs",
@@ -27015,7 +27612,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/config.rs",
@@ -27181,7 +27778,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 95.41322,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/mod.rs",
@@ -27260,7 +27857,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.26568,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/rules.rs",
@@ -27545,7 +28142,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.31457,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/runner.rs",
@@ -27640,7 +28237,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/scoring.rs",
@@ -27711,7 +28308,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.893616,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/comply/tests.rs",
@@ -27820,8 +28417,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -27877,7 +28475,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/analyzer.rs",
@@ -27948,7 +28546,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.82761,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/deduplicator.rs",
@@ -28035,7 +28633,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/mod.rs",
@@ -28106,7 +28704,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.99123,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/nondeterminism.rs",
@@ -28136,8 +28734,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -28272,7 +28871,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.3,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/config/quoter.rs",
@@ -28294,8 +28893,9 @@
             "issue": "High cognitive complexity: 34"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -28351,7 +28951,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/container/distroless.rs",
@@ -28422,7 +29022,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/container/mod.rs",
@@ -28656,9 +29256,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/adversarial_templates_part2_incl2.rs",
@@ -28720,7 +29320,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 99.66667,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/adversarial_templates_unsafe.rs",
@@ -28799,7 +29399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/baselines.rs",
@@ -28870,7 +29470,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.48541,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/benchmark_export.rs",
@@ -28957,7 +29557,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/benchmark_publish.rs",
@@ -29107,7 +29707,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.09722,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/classifier.rs",
@@ -29194,7 +29794,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/contract_validation.rs",
@@ -29265,7 +29865,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.90849,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/convergence.rs",
@@ -29352,7 +29952,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/conversations.rs",
@@ -29502,7 +30102,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset.rs",
@@ -29589,7 +30189,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.67778,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_derive.rs",
@@ -29684,7 +30284,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_export.rs",
@@ -29763,7 +30363,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.5,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_exportformat.rs",
@@ -29927,9 +30527,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_part2_incl2.rs",
@@ -29989,9 +30589,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/dataset_part3_incl2.rs",
@@ -30053,7 +30653,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.746994,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/domain_categories.rs",
@@ -30322,7 +30922,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/evaluation.rs",
@@ -30393,7 +30993,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.6,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/expansion_generator.rs",
@@ -30480,7 +31080,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/graph_priority.rs",
@@ -30630,7 +31230,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 97.045456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/mod.rs",
@@ -30962,7 +31562,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.82222,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/quality_gates.rs",
@@ -31057,7 +31657,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data.rs",
@@ -31128,7 +31728,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_corpusregistry.rs",
@@ -31199,7 +31799,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_load.rs",
@@ -31268,9 +31868,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/corpus_data_part2_incl2.rs",
@@ -31332,7 +31932,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/registry/mod.rs",
@@ -31419,7 +32019,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.61539,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/runner.rs",
@@ -31593,7 +32193,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/runner_cont_4.rs",
@@ -31916,7 +32516,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/schema_enforcement.rs",
@@ -32098,7 +32698,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/schema_enforcement_part2_incl2.rs",
@@ -32239,7 +32839,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.4968,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/tier_analysis.rs",
@@ -32421,7 +33021,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/corpus/training_config.rs",
@@ -32666,7 +33266,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile.rs",
@@ -32737,7 +33337,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_cont.rs",
@@ -32799,7 +33399,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_converter.rs",
@@ -32894,7 +33494,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.63576,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_coverage_tests2.rs",
@@ -32971,9 +33571,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/makefile_part2_incl2.rs",
@@ -33035,7 +33635,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 97.226105,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/mod.rs",
@@ -33201,7 +33801,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.55351,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/posix_emit_ir.rs",
@@ -33391,7 +33991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.63367,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/posix_runtime.rs",
@@ -33557,7 +34157,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/emitter/trace.rs",
@@ -33619,7 +34219,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/abstract_state.rs",
@@ -33690,7 +34290,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/emitter.rs",
@@ -33761,7 +34361,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.9284,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state.rs",
@@ -33848,7 +34448,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.90807,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state_enhancedfilesystementry.rs",
@@ -33933,9 +34533,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/enhanced_state_part2_incl2.rs",
@@ -34076,7 +34676,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.489655,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/kani_harnesses.rs",
@@ -34163,7 +34763,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/mod.rs",
@@ -34313,7 +34913,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 82.77778,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/semantics.rs",
@@ -34408,7 +35008,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formal/tiny_ast.rs",
@@ -34422,8 +35022,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -34566,7 +35167,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/dialect.rs",
@@ -34604,8 +35205,9 @@
             "issue": "High cyclomatic complexity: 58"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 15,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -34661,7 +35263,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.5545,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/engine.rs",
@@ -34835,7 +35437,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/mod.rs",
@@ -34906,7 +35508,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/source_map.rs",
@@ -35054,9 +35656,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/transforms_part2_incl2.rs",
@@ -35118,7 +35720,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/formatter/types.rs",
@@ -35268,7 +35870,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.33333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/generated_contracts.rs",
@@ -35434,7 +36036,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.60477,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_audit.rs",
@@ -35521,7 +36123,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.815125,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_auditcontext.rs",
@@ -35701,9 +36303,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part2_incl2.rs",
@@ -35763,9 +36365,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part3_incl2.rs",
@@ -35825,9 +36427,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/audit_part4_incl2.rs",
@@ -36047,7 +36649,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container.rs",
@@ -36126,7 +36728,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_containerruntime.rs",
@@ -36205,7 +36807,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_matrixsummary.rs",
@@ -36274,9 +36876,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/container_part2_incl2.rs",
@@ -36338,7 +36940,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.02829,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/distributed.rs",
@@ -36504,7 +37106,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.74707,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/dry_run_dryrunsummary.rs",
@@ -36583,7 +37185,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 87.38763,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/executor.rs",
@@ -36678,7 +37280,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/falsification.rs",
@@ -36749,7 +37351,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/from_bash.rs",
@@ -36828,7 +37430,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/from_bash_generate.rs",
@@ -37071,9 +37673,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/golden_trace_part2_incl2.rs",
@@ -37230,7 +37832,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/metrics.rs",
@@ -37301,7 +37903,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/metrics_format.rs",
@@ -37372,7 +37974,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/mod.rs",
@@ -37443,7 +38045,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/plan.rs",
@@ -37607,9 +38209,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/progress_part2_incl2.rs",
@@ -37671,7 +38273,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/progress_stepstate.rs",
@@ -37758,7 +38360,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/rollback.rs",
@@ -37908,7 +38510,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 99.2,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/spec.rs",
@@ -38145,7 +38747,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/installer/tracing_logger.rs",
@@ -38216,7 +38818,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.08694,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert.rs",
@@ -38382,7 +38984,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.754486,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert_expr_tests3.rs",
@@ -38548,7 +39150,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.553955,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/convert_stmt.rs",
@@ -38722,7 +39324,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/effects.rs",
@@ -38888,7 +39490,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.74074,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/expr_calls.rs",
@@ -38983,7 +39585,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 95.61497,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/mod.rs",
@@ -39149,7 +39751,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.04211,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/pattern.rs",
@@ -39244,7 +39846,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.77313,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/shell_ir.rs",
@@ -39339,7 +39941,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.828575,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/ir/tests.rs",
@@ -39505,7 +40107,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/autofix.rs",
@@ -39663,7 +40265,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic.rs",
@@ -39734,7 +40336,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_lintresult.rs",
@@ -39803,9 +40405,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_part2_incl2.rs",
@@ -39867,7 +40469,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/diagnostic_span.rs",
@@ -39938,7 +40540,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/docker_profiler.rs",
@@ -40068,6 +40670,85 @@
       },
       "git_context": null
     },
+    "./rash/src/linter/heredoc.rs": {
+      "content_hash": [
+        164,
+        114,
+        70,
+        46,
+        43,
+        116,
+        81,
+        201,
+        130,
+        76,
+        37,
+        83,
+        61,
+        71,
+        91,
+        75,
+        102,
+        5,
+        48,
+        38,
+        117,
+        75,
+        118,
+        37,
+        230,
+        141,
+        204,
+        247,
+        21,
+        139,
+        17,
+        200
+      ],
+      "score": {
+        "structural_complexity": 22.6,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 6.5,
+        "total": 94.63636,
+        "grade": "A",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./rash/src/linter/heredoc.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 3.5,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 7 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 2.4,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 23"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
     "./rash/src/linter/ignore_file.rs": {
       "content_hash": [
         19,
@@ -40112,7 +40793,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.3,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/ignore_file.rs",
@@ -40199,7 +40880,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.525925,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/make_preprocess.rs",
@@ -40237,8 +40918,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -40252,49 +40934,49 @@
     },
     "./rash/src/linter/mod.rs": {
       "content_hash": [
-        119,
-        186,
-        47,
-        97,
-        235,
-        152,
+        123,
+        43,
+        153,
         105,
-        12,
-        186,
-        152,
-        38,
-        201,
-        87,
-        142,
-        118,
-        37,
-        229,
-        110,
-        137,
-        173,
-        152,
-        30,
-        108,
-        71,
-        145,
-        245,
-        170,
-        5,
-        205,
-        175,
+        39,
+        40,
+        183,
+        206,
+        13,
+        91,
+        194,
         235,
-        235
+        2,
+        164,
+        182,
+        43,
+        51,
+        168,
+        19,
+        142,
+        207,
+        251,
+        198,
+        229,
+        172,
+        218,
+        44,
+        195,
+        163,
+        158,
+        53,
+        150
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.931034,
+        "duplication_ratio": 17.966103,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 9.5,
-        "total": 97.66457,
-        "grade": "APlus",
+        "total": 97.69646,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/mod.rs",
@@ -40309,11 +40991,11 @@
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.0689657,
+            "amount": 2.0338984,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 10.3%"
+            "issue": "Code duplication: 10.2%"
           }
         ],
         "critical_defects_count": 0,
@@ -40452,7 +41134,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry.rs",
@@ -40523,7 +41205,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data.rs",
@@ -40594,7 +41276,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.8877,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_1.rs",
@@ -40673,7 +41355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.764046,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_11.rs",
@@ -40752,7 +41434,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.80899,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_12.rs",
@@ -40910,7 +41592,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 98.68065,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_2.rs",
@@ -40989,7 +41671,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.0,
         "total": 98.915665,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_3.rs",
@@ -41147,7 +41829,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.621414,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_4.rs",
@@ -41226,7 +41908,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.95681,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_4_more.rs",
@@ -41305,7 +41987,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rule_registry_data_ext.rs",
@@ -41534,7 +42216,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.33312,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash003.rs",
@@ -41629,7 +42311,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.78571,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash004.rs",
@@ -41716,7 +42398,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.4279,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash005.rs",
@@ -41890,7 +42572,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.791306,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/bash007.rs",
@@ -42222,7 +42904,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.39139,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/coursera.rs",
@@ -42317,7 +42999,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/det001.rs",
@@ -42633,7 +43315,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.868546,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/devcontainer.rs",
@@ -42728,7 +43410,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/devcontainer_logic.rs",
@@ -42965,7 +43647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.36363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker003.rs",
@@ -43044,7 +43726,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker004.rs",
@@ -43115,7 +43797,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker005.rs",
@@ -43186,7 +43868,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker006.rs",
@@ -43257,7 +43939,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.19292,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker007.rs",
@@ -43526,7 +44208,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.17143,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker010.rs",
@@ -43605,7 +44287,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/docker010_logic.rs",
@@ -43921,7 +44603,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/idem002.rs",
@@ -44014,8 +44696,9 @@
             "issue": "Code duplication: 10.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -44071,7 +44754,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.06207,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/launchd001.rs",
@@ -44282,49 +44965,49 @@
     },
     "./rash/src/linter/rules/make003.rs": {
       "content_hash": [
-        100,
-        214,
-        144,
-        47,
-        135,
-        250,
-        137,
-        245,
-        204,
-        210,
-        209,
-        229,
-        13,
+        111,
+        118,
+        72,
+        164,
+        203,
+        236,
+        231,
+        124,
+        59,
+        192,
+        133,
+        97,
         29,
+        153,
+        243,
+        127,
         109,
-        38,
-        145,
-        43,
-        6,
-        44,
-        119,
-        181,
-        105,
-        11,
-        199,
-        226,
-        230,
-        199,
-        80,
-        112,
-        199,
-        135
+        236,
+        207,
+        99,
+        223,
+        134,
+        26,
+        139,
+        19,
+        170,
+        65,
+        235,
+        205,
+        133,
+        128,
+        162
       ],
       "score": {
-        "structural_complexity": 15.099999,
+        "structural_complexity": 15.0,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 95.1,
-        "grade": "APlus",
+        "total": 95.0,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make003.rs",
@@ -44335,15 +45018,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 15 duplicate code patterns"
+            "issue": "Found 17 duplicate code patterns"
           },
           {
             "source_metric": "StructuralComplexity",
-            "amount": 9.900001,
+            "amount": 10.0,
             "applied_to": [
               "StructuralComplexity"
             ],
-            "issue": "High cognitive complexity: 48"
+            "issue": "High cognitive complexity: 51"
           }
         ],
         "critical_defects_count": 0,
@@ -44482,7 +45165,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.9713,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make005.rs",
@@ -44569,7 +45252,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.76364,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make006.rs",
@@ -44743,7 +45426,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.71658,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make008.rs",
@@ -44875,48 +45558,48 @@
     },
     "./rash/src/linter/rules/make010.rs": {
       "content_hash": [
-        169,
-        4,
-        12,
-        8,
-        205,
-        82,
-        93,
-        213,
-        113,
-        221,
-        2,
-        153,
-        219,
-        6,
-        230,
-        136,
-        225,
-        232,
-        81,
-        189,
-        125,
-        44,
-        255,
-        254,
-        247,
-        99,
-        171,
-        244,
-        23,
-        180,
+        114,
+        18,
         145,
-        89
+        141,
+        45,
+        116,
+        252,
+        179,
+        97,
+        121,
+        139,
+        219,
+        33,
+        88,
+        65,
+        36,
+        187,
+        67,
+        208,
+        253,
+        221,
+        231,
+        87,
+        251,
+        45,
+        92,
+        60,
+        21,
+        8,
+        209,
+        76,
+        27
       ],
       "score": {
         "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 16.750902,
+        "duplication_ratio": 17.003258,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 92.50082,
+        "total": 92.73024,
         "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
@@ -44928,15 +45611,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 23 duplicate code patterns"
+            "issue": "Found 24 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 3.2490973,
+            "amount": 2.9967427,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 16.2%"
+            "issue": "Code duplication: 15.0%"
           }
         ],
         "critical_defects_count": 0,
@@ -44996,7 +45679,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.28926,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make011.rs",
@@ -45349,68 +46032,60 @@
     },
     "./rash/src/linter/rules/make016.rs": {
       "content_hash": [
+        205,
+        46,
+        44,
+        191,
+        156,
+        56,
+        91,
+        46,
+        228,
+        156,
+        190,
+        245,
+        56,
         97,
-        254,
-        115,
-        195,
-        121,
-        251,
-        144,
-        104,
-        67,
-        244,
-        3,
-        182,
-        131,
-        32,
-        237,
-        107,
-        62,
+        155,
+        106,
+        153,
+        154,
+        183,
+        96,
+        178,
+        213,
         14,
-        135,
-        221,
-        120,
-        29,
-        24,
-        9,
-        145,
-        5,
-        182,
-        201,
-        104,
-        161,
-        255,
-        184
+        134,
+        151,
+        103,
+        47,
+        196,
+        75,
+        57,
+        214,
+        86
       ],
       "score": {
-        "structural_complexity": 20.8,
+        "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
         "duplication_ratio": 20.0,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 5.0,
-        "total": 91.63637,
-        "grade": "A",
+        "entropy_score": 9.0,
+        "total": 99.09091,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make016.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 5.0,
+            "amount": 1.0,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 10 duplicate code patterns"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 4.2000003,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 29"
+            "issue": "Found 2 duplicate code patterns"
           }
         ],
         "critical_defects_count": 0,
@@ -45644,7 +46319,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.32468,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/make019.rs",
@@ -45810,7 +46485,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod.rs",
@@ -45872,7 +46547,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_helpers.rs",
@@ -45934,7 +46609,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint.rs",
@@ -45963,38 +46638,38 @@
     },
     "./rash/src/linter/rules/mod_lint_2.rs": {
       "content_hash": [
-        36,
-        42,
-        249,
-        200,
-        243,
-        3,
-        201,
-        40,
         184,
-        245,
-        250,
-        224,
-        236,
-        233,
-        84,
-        68,
-        3,
-        185,
-        232,
-        163,
-        184,
-        52,
-        183,
-        192,
-        74,
-        129,
-        161,
-        43,
+        64,
         108,
-        141,
+        121,
+        54,
+        112,
+        157,
+        47,
+        88,
+        121,
+        201,
+        35,
+        79,
+        237,
+        160,
+        90,
+        190,
+        134,
+        3,
         177,
-        219
+        225,
+        53,
+        201,
+        4,
+        94,
+        228,
+        244,
+        136,
+        144,
+        153,
+        146,
+        115
       ],
       "score": {
         "structural_complexity": 25.0,
@@ -46003,20 +46678,20 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 9.0,
-        "total": 99.09091,
-        "grade": "APlus",
+        "entropy_score": 8.5,
+        "total": 98.63637,
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint_2.rs",
         "penalties_applied": [
           {
             "source_metric": "Duplication",
-            "amount": 1.0,
+            "amount": 1.5,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 2 duplicate code patterns"
+            "issue": "Found 3 duplicate code patterns"
           }
         ],
         "critical_defects_count": 0,
@@ -46076,7 +46751,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_lint_more.rs",
@@ -46136,9 +46811,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_part2_incl2.rs",
@@ -46200,7 +46875,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/mod_std.rs",
@@ -46271,7 +46946,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf001.rs",
@@ -46285,8 +46960,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46342,7 +47018,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.37573,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf002.rs",
@@ -46437,7 +47113,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf003.rs",
@@ -46451,8 +47127,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46508,7 +47185,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.252525,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/perf004.rs",
@@ -46530,8 +47207,9 @@
             "issue": "Code duplication: 11.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46609,8 +47287,9 @@
             "issue": "Code duplication: 13.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46666,7 +47345,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.53669,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port001.rs",
@@ -46688,8 +47367,9 @@
             "issue": "Code duplication: 12.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46745,7 +47425,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port002.rs",
@@ -46816,7 +47496,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.8134,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port003.rs",
@@ -46895,7 +47575,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port004.rs",
@@ -46909,8 +47589,9 @@
             "issue": "Found 6 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -46966,7 +47647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/port005.rs",
@@ -47037,7 +47718,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.04638,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/rel001.rs",
@@ -47059,8 +47740,9 @@
             "issue": "Code duplication: 12.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47116,7 +47798,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/rel002.rs",
@@ -47225,8 +47907,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47391,8 +48074,9 @@
             "issue": "Code duplication: 11.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47527,7 +48211,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1004.rs",
@@ -47843,7 +48527,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1012.rs",
@@ -47914,7 +48598,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.344345,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1014.rs",
@@ -47936,8 +48620,9 @@
             "issue": "Code duplication: 10.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -47993,7 +48678,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.570114,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1017.rs",
@@ -48072,7 +48757,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.570114,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1018.rs",
@@ -48238,7 +48923,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.79889,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1026.rs",
@@ -48260,8 +48945,9 @@
             "issue": "Code duplication: 10.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48404,7 +49090,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.72728,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1035.rs",
@@ -48513,8 +49199,9 @@
             "issue": "Code duplication: 18.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48649,7 +49336,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.862465,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1038.rs",
@@ -48815,7 +49502,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1041.rs",
@@ -48829,8 +49516,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48916,8 +49604,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -48973,7 +49662,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 97.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1045.rs",
@@ -49052,7 +49741,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.090904,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1065.rs",
@@ -49074,8 +49763,9 @@
             "issue": "Code duplication: 12.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49131,7 +49821,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.78788,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1066.rs",
@@ -49153,8 +49843,9 @@
             "issue": "Code duplication: 10.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49210,7 +49901,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 97.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1068.rs",
@@ -49297,7 +49988,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1069.rs",
@@ -49368,7 +50059,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.4282,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1075.rs",
@@ -49390,8 +50081,9 @@
             "issue": "Code duplication: 10.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -49447,7 +50139,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.366,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1076.rs",
@@ -49526,7 +50218,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.29838,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1078.rs",
@@ -49613,7 +50305,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 95.72728,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1079.rs",
@@ -49692,7 +50384,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.12987,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1082.rs",
@@ -49937,7 +50629,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.882744,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1086.rs",
@@ -49959,8 +50651,9 @@
             "issue": "Code duplication: 10.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50046,8 +50739,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50103,7 +50797,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.89375,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1090.rs",
@@ -50190,7 +50884,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.86363,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1091.rs",
@@ -50364,7 +51058,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1095.rs",
@@ -50435,7 +51129,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.061424,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1097.rs",
@@ -50457,8 +51151,9 @@
             "issue": "Code duplication: 12.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -50514,7 +51209,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1098.rs",
@@ -50743,7 +51438,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.16645,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1101.rs",
@@ -50980,7 +51675,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1106.rs",
@@ -51146,7 +51841,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1110.rs",
@@ -51217,7 +51912,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1111.rs",
@@ -51604,7 +52299,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.38961,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1120.rs",
@@ -51849,7 +52544,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1129.rs",
@@ -51920,7 +52615,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.30121,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1131.rs",
@@ -51999,7 +52694,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1135.rs",
@@ -52070,7 +52765,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.482605,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc1139.rs",
@@ -52266,8 +52961,9 @@
             "issue": "Code duplication: 23.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 10,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52345,8 +53041,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52424,8 +53121,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52481,7 +53179,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.143326,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2004.rs",
@@ -52503,8 +53201,9 @@
             "issue": "Code duplication: 11.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52582,8 +53281,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52597,49 +53297,49 @@
     },
     "./rash/src/linter/rules/sc2006.rs": {
       "content_hash": [
-        33,
-        207,
-        204,
-        102,
-        95,
         61,
-        218,
-        116,
-        173,
-        241,
-        245,
-        245,
-        113,
-        245,
-        121,
-        128,
-        216,
-        253,
-        17,
-        186,
-        38,
         104,
-        238,
-        218,
-        4,
-        218,
-        239,
+        140,
+        144,
+        37,
+        59,
+        194,
+        56,
+        246,
+        229,
+        142,
+        17,
+        52,
+        162,
+        233,
+        229,
+        92,
+        51,
+        162,
+        231,
+        0,
+        101,
+        62,
         90,
-        183,
-        68,
-        71,
-        161
+        53,
+        203,
+        122,
+        182,
+        51,
+        21,
+        121,
+        199
       ],
       "score": {
-        "structural_complexity": 22.9,
+        "structural_complexity": 25.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 15.833334,
+        "duplication_ratio": 15.396826,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 98.73334,
-        "grade": "APlus",
+        "total": 91.269844,
+        "grade": "A",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2006.rs",
@@ -52650,27 +53350,20 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 18 duplicate code patterns"
+            "issue": "Found 17 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 4.1666665,
+            "amount": 4.6031747,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 20.8%"
-          },
-          {
-            "source_metric": "StructuralComplexity",
-            "amount": 2.1000001,
-            "applied_to": [
-              "StructuralComplexity"
-            ],
-            "issue": "High cognitive complexity: 22"
+            "issue": "Code duplication: 23.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52748,8 +53441,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52827,8 +53521,9 @@
             "issue": "Code duplication: 17.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52906,8 +53601,9 @@
             "issue": "Code duplication: 16.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -52963,7 +53659,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2010.rs",
@@ -52977,8 +53673,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53034,7 +53731,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2011.rs",
@@ -53048,8 +53745,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53105,7 +53803,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2012.rs",
@@ -53119,8 +53817,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53176,7 +53875,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2013.rs",
@@ -53190,8 +53889,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53247,7 +53947,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2014.rs",
@@ -53261,8 +53961,9 @@
             "issue": "Found 5 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53340,8 +54041,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53419,8 +54121,9 @@
             "issue": "Code duplication: 18.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53498,8 +54201,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53577,8 +54281,9 @@
             "issue": "Code duplication: 13.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53656,8 +54361,9 @@
             "issue": "Code duplication: 13.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53735,8 +54441,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53814,8 +54521,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53893,8 +54601,9 @@
             "issue": "Code duplication: 18.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -53972,8 +54681,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54029,7 +54739,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2024.rs",
@@ -54130,8 +54840,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54209,8 +54920,9 @@
             "issue": "Code duplication: 12.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54288,8 +55000,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54367,8 +55080,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54446,8 +55160,9 @@
             "issue": "Code duplication: 15.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54525,8 +55240,9 @@
             "issue": "Code duplication: 14.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54612,8 +55328,9 @@
             "issue": "High cognitive complexity: 46"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54691,8 +55408,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54770,8 +55488,9 @@
             "issue": "Code duplication: 19.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -54849,8 +55568,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55080,7 +55800,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.683334,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2037.rs",
@@ -55110,8 +55830,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55189,8 +55910,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55246,7 +55968,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.666664,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2039.rs",
@@ -55268,8 +55990,9 @@
             "issue": "Code duplication: 26.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55347,8 +56070,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55404,7 +56128,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.84729,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2041.rs",
@@ -55434,8 +56158,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55513,8 +56238,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55592,8 +56318,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55671,8 +56398,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55750,8 +56478,9 @@
             "issue": "Code duplication: 20.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55829,8 +56558,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55908,8 +56638,9 @@
             "issue": "Code duplication: 12.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -55987,8 +56718,9 @@
             "issue": "Code duplication: 15.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56066,8 +56798,9 @@
             "issue": "Code duplication: 22.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56145,8 +56878,9 @@
             "issue": "Code duplication: 12.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56224,8 +56958,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56303,8 +57038,9 @@
             "issue": "Code duplication: 15.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56390,8 +57126,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56469,8 +57206,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56548,8 +57286,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56627,8 +57366,9 @@
             "issue": "Code duplication: 17.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56706,8 +57446,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56864,8 +57605,9 @@
             "issue": "Code duplication: 24.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -56943,8 +57685,9 @@
             "issue": "Code duplication: 17.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57022,8 +57765,9 @@
             "issue": "Code duplication: 14.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57109,8 +57853,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57188,8 +57933,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57245,7 +57991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2064.rs",
@@ -57316,7 +58062,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2064_logic.rs",
@@ -57330,8 +58076,9 @@
             "issue": "Found 7 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57496,8 +58243,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57575,8 +58323,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57654,8 +58403,9 @@
             "issue": "Code duplication: 20.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57733,8 +58483,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57812,8 +58563,9 @@
             "issue": "Code duplication: 14.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57891,8 +58643,9 @@
             "issue": "Code duplication: 19.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -57948,7 +58701,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.17842,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2072.rs",
@@ -57970,8 +58723,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58049,8 +58803,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58128,8 +58883,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58207,8 +58963,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58286,8 +59043,9 @@
             "issue": "Code duplication: 14.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58365,8 +59123,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58444,8 +59203,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58523,8 +59283,9 @@
             "issue": "Code duplication: 18.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58610,8 +59371,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58689,8 +59451,9 @@
             "issue": "Code duplication: 19.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58768,8 +59531,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -58926,8 +59690,9 @@
             "issue": "Code duplication: 17.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59005,8 +59770,9 @@
             "issue": "Code duplication: 14.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59062,7 +59828,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2086.rs",
@@ -59218,9 +59984,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2086_part2_incl2.rs",
@@ -59304,8 +60070,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59462,8 +60229,9 @@
             "issue": "Code duplication: 17.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59541,8 +60309,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59620,8 +60389,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59677,7 +60447,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2092.rs",
@@ -59707,8 +60477,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59786,8 +60557,9 @@
             "issue": "Code duplication: 22.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -59843,7 +60615,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.76666,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2094.rs",
@@ -59952,8 +60724,9 @@
             "issue": "Code duplication: 23.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 9,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60009,7 +60782,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2096.rs",
@@ -60031,8 +60804,9 @@
             "issue": "High cognitive complexity: 40"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60110,8 +60884,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60189,8 +60964,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 12,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60268,8 +61044,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60347,8 +61124,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60426,8 +61204,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60483,7 +61262,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.022095,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2102.rs",
@@ -60513,8 +61292,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60592,8 +61372,9 @@
             "issue": "Code duplication: 20.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60649,7 +61430,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.963005,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2104.rs",
@@ -60679,8 +61460,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60758,8 +61540,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60837,8 +61620,9 @@
             "issue": "Code duplication: 18.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60916,8 +61700,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -60995,8 +61780,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61074,8 +61860,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61153,8 +61940,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61232,8 +62020,9 @@
             "issue": "Code duplication: 14.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61311,8 +62100,9 @@
             "issue": "Code duplication: 15.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61390,8 +62180,9 @@
             "issue": "Code duplication: 17.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61469,8 +62260,9 @@
             "issue": "Code duplication: 18.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61548,8 +62340,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61627,8 +62420,9 @@
             "issue": "Code duplication: 13.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61684,7 +62478,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.28863,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2117.rs",
@@ -61714,8 +62508,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61793,8 +62588,9 @@
             "issue": "Code duplication: 14.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61850,7 +62646,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.379166,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2119.rs",
@@ -61880,8 +62676,9 @@
             "issue": "High cognitive complexity: 27"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 7,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -61937,7 +62734,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.076996,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2120.rs",
@@ -61967,8 +62764,9 @@
             "issue": "High cognitive complexity: 29"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62046,8 +62844,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62125,8 +62924,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62204,8 +63004,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62283,8 +63084,9 @@
             "issue": "Code duplication: 14.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62340,7 +63142,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.005615,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2125.rs",
@@ -62370,8 +63172,9 @@
             "issue": "High cognitive complexity: 32"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62449,8 +63252,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62528,8 +63332,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62585,7 +63390,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.287964,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2128.rs",
@@ -62615,8 +63420,9 @@
             "issue": "High cognitive complexity: 22"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62672,7 +63478,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.782394,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2129.rs",
@@ -62702,8 +63508,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62860,8 +63667,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -62917,7 +63725,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.43827,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2132.rs",
@@ -62947,8 +63755,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63026,8 +63835,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63105,8 +63915,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63184,8 +63995,9 @@
             "issue": "Code duplication: 22.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63263,8 +64075,9 @@
             "issue": "Code duplication: 20.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63342,8 +64155,9 @@
             "issue": "Code duplication: 14.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63421,8 +64235,9 @@
             "issue": "Code duplication: 20.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63500,8 +64315,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63579,8 +64395,9 @@
             "issue": "Code duplication: 15.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63658,8 +64475,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63737,8 +64555,9 @@
             "issue": "Code duplication: 21.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63895,8 +64714,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -63974,8 +64794,9 @@
             "issue": "Code duplication: 18.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64053,8 +64874,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64132,8 +64954,9 @@
             "issue": "Code duplication: 20.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64290,8 +65113,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64369,8 +65193,9 @@
             "issue": "Code duplication: 16.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64464,8 +65289,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64559,8 +65385,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64616,7 +65443,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.73189,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2153.rs",
@@ -64646,8 +65473,9 @@
             "issue": "High cognitive complexity: 30"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64703,7 +65531,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2154.rs",
@@ -64883,8 +65711,9 @@
             "issue": "Code duplication: 16.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -64962,8 +65791,9 @@
             "issue": "Code duplication: 21.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65136,8 +65966,9 @@
             "issue": "Code duplication: 15.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65215,8 +66046,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65294,8 +66126,9 @@
             "issue": "Code duplication: 16.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65373,8 +66206,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65452,8 +66286,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65531,8 +66366,9 @@
             "issue": "Code duplication: 16.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65610,8 +66446,9 @@
             "issue": "Code duplication: 17.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65689,8 +66526,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65768,8 +66606,9 @@
             "issue": "Code duplication: 14.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -65825,7 +66664,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2167.rs",
@@ -65896,7 +66735,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2168.rs",
@@ -65918,8 +66757,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66054,7 +66894,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.27143,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2170.rs",
@@ -66092,8 +66932,9 @@
             "issue": "High cognitive complexity: 26"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66179,8 +67020,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66236,7 +67078,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 95.19763,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2172.rs",
@@ -66416,8 +67258,9 @@
             "issue": "Code duplication: 18.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66473,7 +67316,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2175.rs",
@@ -66566,8 +67409,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66623,7 +67467,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2177.rs",
@@ -66694,7 +67538,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2178.rs",
@@ -66724,8 +67568,9 @@
             "issue": "High cognitive complexity: 25"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66803,8 +67648,9 @@
             "issue": "Code duplication: 16.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66882,8 +67728,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -66961,8 +67808,9 @@
             "issue": "Code duplication: 17.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67040,8 +67888,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67097,7 +67946,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2183.rs",
@@ -67111,8 +67960,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67168,7 +68018,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2184.rs",
@@ -67239,7 +68089,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2185.rs",
@@ -67310,7 +68160,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2186.rs",
@@ -67324,8 +68174,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67381,7 +68232,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2187.rs",
@@ -67474,8 +68325,9 @@
             "issue": "Code duplication: 14.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67531,7 +68383,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2189.rs",
@@ -67632,8 +68484,9 @@
             "issue": "High cognitive complexity: 17"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67711,8 +68564,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67768,7 +68622,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2192.rs",
@@ -67839,7 +68693,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2193.rs",
@@ -67932,8 +68786,9 @@
             "issue": "Code duplication: 13.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -67989,7 +68844,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2195.rs",
@@ -68082,8 +68937,9 @@
             "issue": "Code duplication: 23.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 4,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68139,7 +68995,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2197.rs",
@@ -68240,8 +69096,9 @@
             "issue": "High cognitive complexity: 19"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68297,7 +69154,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.41818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2199.rs",
@@ -68327,8 +69184,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68406,8 +69264,9 @@
             "issue": "Code duplication: 18.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68493,8 +69352,9 @@
             "issue": "High cognitive complexity: 16"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68550,7 +69410,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2202.rs",
@@ -68621,7 +69481,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2203.rs",
@@ -68635,8 +69495,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68692,7 +69553,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2204.rs",
@@ -68706,8 +69567,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68763,7 +69625,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2205.rs",
@@ -68856,8 +69718,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -68935,8 +69798,9 @@
             "issue": "Code duplication: 17.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69014,8 +69878,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69071,7 +69936,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.88319,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2209.rs",
@@ -69101,8 +69966,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69180,8 +70046,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69259,8 +70126,9 @@
             "issue": "Code duplication: 16.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69338,8 +70206,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69474,7 +70343,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 95.54677,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2214.rs",
@@ -69654,8 +70523,9 @@
             "issue": "Code duplication: 18.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69733,8 +70603,9 @@
             "issue": "Code duplication: 15.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -69891,8 +70762,9 @@
             "issue": "Code duplication: 17.4%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70207,8 +71079,9 @@
             "issue": "Code duplication: 18.2%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70286,8 +71159,9 @@
             "issue": "Code duplication: 15.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70365,8 +71239,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70523,8 +71398,9 @@
             "issue": "Code duplication: 16.9%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70760,8 +71636,9 @@
             "issue": "Code duplication: 16.5%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70839,8 +71716,9 @@
             "issue": "Code duplication: 17.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -70997,8 +71875,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71076,8 +71955,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71155,8 +72035,9 @@
             "issue": "Code duplication: 19.1%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71234,8 +72115,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71392,8 +72274,9 @@
             "issue": "Code duplication: 17.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71874,8 +72757,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -71953,8 +72837,9 @@
             "issue": "Code duplication: 18.0%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72089,7 +72974,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.74,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2247.rs",
@@ -72119,8 +73004,9 @@
             "issue": "High cognitive complexity: 20"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72198,8 +73084,9 @@
             "issue": "Code duplication: 18.7%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72571,7 +73458,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2253.rs",
@@ -72642,7 +73529,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2254.rs",
@@ -72713,7 +73600,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2255.rs",
@@ -72784,7 +73671,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2256.rs",
@@ -72798,8 +73685,9 @@
             "issue": "Found 2 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -72855,7 +73743,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2257.rs",
@@ -72926,7 +73814,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2258.rs",
@@ -72997,7 +73885,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2259.rs",
@@ -73011,8 +73899,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73068,7 +73957,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2260.rs",
@@ -73139,7 +74028,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2261.rs",
@@ -73210,7 +74099,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2262.rs",
@@ -73281,7 +74170,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2263.rs",
@@ -73352,7 +74241,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2264.rs",
@@ -73423,7 +74312,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2265.rs",
@@ -73437,8 +74326,9 @@
             "issue": "Found 2 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73494,7 +74384,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2266.rs",
@@ -73508,8 +74398,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73565,7 +74456,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2267.rs",
@@ -73579,8 +74470,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73636,7 +74528,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2268.rs",
@@ -73650,8 +74542,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73707,7 +74600,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2269.rs",
@@ -73721,8 +74614,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73778,7 +74672,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2270.rs",
@@ -73792,8 +74686,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73849,7 +74744,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2271.rs",
@@ -73920,7 +74815,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2272.rs",
@@ -73934,8 +74829,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -73991,7 +74887,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2273.rs",
@@ -74005,8 +74901,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74062,7 +74959,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2274.rs",
@@ -74076,8 +74973,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74133,7 +75031,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2275.rs",
@@ -74147,8 +75045,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74204,7 +75103,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2276.rs",
@@ -74218,8 +75117,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74275,7 +75175,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2277.rs",
@@ -74289,8 +75189,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74346,7 +75247,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2278.rs",
@@ -74360,8 +75261,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74417,7 +75319,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2279.rs",
@@ -74431,8 +75333,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74488,7 +75391,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2280.rs",
@@ -74502,8 +75405,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74581,8 +75485,9 @@
             "issue": "Code duplication: 13.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74638,7 +75543,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2282.rs",
@@ -74652,8 +75557,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74709,7 +75615,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2283.rs",
@@ -74723,8 +75629,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74780,7 +75687,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2284.rs",
@@ -74794,8 +75701,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74851,7 +75759,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2285.rs",
@@ -74865,8 +75773,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74922,7 +75831,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2286.rs",
@@ -74936,8 +75845,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -74993,7 +75903,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2287.rs",
@@ -75007,8 +75917,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75064,7 +75975,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2288.rs",
@@ -75078,8 +75989,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75135,7 +76047,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2289.rs",
@@ -75149,8 +76061,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75206,7 +76119,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2290.rs",
@@ -75220,8 +76133,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75277,7 +76191,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2291.rs",
@@ -75291,8 +76205,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75348,7 +76263,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2292.rs",
@@ -75362,8 +76277,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75419,7 +76335,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2293.rs",
@@ -75433,8 +76349,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75490,7 +76407,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2294.rs",
@@ -75504,8 +76421,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75561,7 +76479,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2295.rs",
@@ -75575,8 +76493,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75632,7 +76551,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2296.rs",
@@ -75646,8 +76565,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75703,7 +76623,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2297.rs",
@@ -75717,8 +76637,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75774,7 +76695,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2298.rs",
@@ -75788,8 +76709,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75845,7 +76767,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 96.1235,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2299.rs",
@@ -75867,8 +76789,9 @@
             "issue": "Code duplication: 11.3%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75924,7 +76847,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2300.rs",
@@ -75938,8 +76861,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -75995,7 +76919,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2301.rs",
@@ -76009,8 +76933,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76066,7 +76991,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2302.rs",
@@ -76080,8 +77005,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76137,7 +77063,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2303.rs",
@@ -76151,8 +77077,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76208,7 +77135,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2304.rs",
@@ -76222,8 +77149,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76279,7 +77207,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2305.rs",
@@ -76293,8 +77221,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76350,7 +77279,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2306.rs",
@@ -76364,8 +77293,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76421,7 +77351,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2307.rs",
@@ -76435,8 +77365,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76514,8 +77445,9 @@
             "issue": "Code duplication: 12.6%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76571,7 +77503,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2309.rs",
@@ -76585,8 +77517,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76642,7 +77575,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2310.rs",
@@ -76656,8 +77589,9 @@
             "issue": "Found 15 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 3,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76713,7 +77647,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2311.rs",
@@ -76727,8 +77661,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76784,7 +77719,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 96.4792,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2312.rs",
@@ -76863,7 +77798,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2313.rs",
@@ -76877,8 +77812,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -76934,7 +77870,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2314.rs",
@@ -76948,8 +77884,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77005,7 +77942,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2315.rs",
@@ -77019,8 +77956,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77076,7 +78014,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2316.rs",
@@ -77090,8 +78028,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77147,7 +78086,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.15738,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2317.rs",
@@ -77177,8 +78116,9 @@
             "issue": "High cognitive complexity: 23"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77234,7 +78174,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2318.rs",
@@ -77248,8 +78188,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77327,8 +78268,9 @@
             "issue": "Code duplication: 13.8%"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77384,7 +78326,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2320.rs",
@@ -77398,8 +78340,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77455,7 +78398,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2321.rs",
@@ -77469,8 +78412,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77526,7 +78470,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2322.rs",
@@ -77540,8 +78484,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77597,7 +78542,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2323.rs",
@@ -77611,8 +78556,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77668,7 +78614,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2324.rs",
@@ -77682,8 +78628,9 @@
             "issue": "Found 3 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77739,7 +78686,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sc2325.rs",
@@ -77753,8 +78700,9 @@
             "issue": "Found 4 duplicate code patterns"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -77889,7 +78837,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.3486,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec002.rs",
@@ -77976,7 +78924,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.28174,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec003.rs",
@@ -78063,7 +79011,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.03333,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec004.rs",
@@ -78403,7 +79351,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.23054,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec008.rs",
@@ -78569,7 +79517,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec010.rs",
@@ -78686,8 +79634,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -78838,7 +79787,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.78641,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec012.rs",
@@ -79233,7 +80182,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.1,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec017.rs",
@@ -79328,7 +80277,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.15745,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec018.rs",
@@ -79366,8 +80315,9 @@
             "issue": "High cognitive complexity: 21"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 2,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -79423,7 +80373,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 96.5,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec019.rs",
@@ -79668,7 +80618,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 99.72273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/sec022.rs",
@@ -80079,7 +81029,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.19225,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/rules/systemd001.rs",
@@ -80348,7 +81298,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.891304,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/suppression.rs",
@@ -80443,7 +81393,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 97.72727,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/linter/tests.rs",
@@ -80672,7 +81622,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 85.856606,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/error.rs",
@@ -80765,9 +81715,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/error_part2_incl2.rs",
@@ -80829,7 +81779,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.35715,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/generators.rs",
@@ -80940,7 +81890,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/lexer.rs",
@@ -81002,7 +81952,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/mod.rs",
@@ -81073,7 +82023,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser.rs",
@@ -81152,7 +82102,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.592514,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser_parse.rs",
@@ -81198,8 +82148,9 @@
             "issue": "High cyclomatic complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 5,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -81253,9 +82204,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/parser_part2_incl2.rs",
@@ -81499,7 +82450,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.37508,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/mod.rs",
@@ -81586,7 +82537,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.77907,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/parallel_safety.rs",
@@ -81689,7 +82640,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.7812,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/performance.rs",
@@ -81776,7 +82727,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 89.1573,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/portability.rs",
@@ -81942,7 +82893,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 99.2209,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/purify/reproducible_builds.rs",
@@ -82108,7 +83059,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/semantic.rs",
@@ -82185,9 +83136,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/semantic_part2_incl2.rs",
@@ -82328,7 +83279,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/make_parser/tests/mod.rs",
@@ -82390,7 +83341,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/config.rs",
@@ -82461,7 +83412,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/diagnostic.rs",
@@ -82556,7 +83507,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/error.rs",
@@ -82618,7 +83569,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/models/mod.rs",
@@ -82680,7 +83631,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.64562,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/cfg.rs",
@@ -82949,7 +83900,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.0,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gate_summary.rs",
@@ -83123,7 +84074,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_default_gatesummary.rs",
@@ -83183,9 +84134,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_part2_incl2.rs",
@@ -83245,9 +84196,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/gates_part3_incl2.rs",
@@ -83309,7 +84260,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/lint_report.rs",
@@ -83380,7 +84331,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/lint_report_sbfl.rs",
@@ -83467,7 +84418,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/mock_executor.rs",
@@ -83538,7 +84489,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/mod.rs",
@@ -83686,9 +84637,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/oracle_part2_incl2.rs",
@@ -83748,9 +84699,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/quality/oracle_part3_incl2.rs",
@@ -83978,7 +84929,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/ast_display.rs",
@@ -84134,9 +85085,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/breakpoint_part2_incl2.rs",
@@ -84443,7 +85394,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/debugger_continueresult.rs",
@@ -84821,7 +85772,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.0,
         "total": 98.18182,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/errors.rs",
@@ -84971,7 +85922,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.181816,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/explain.rs",
@@ -85050,7 +86001,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 95.90909,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/help.rs",
@@ -85121,7 +86072,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.21863,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/highlighting.rs",
@@ -85214,9 +86165,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/highlighting_part2_incl2.rs",
@@ -85278,7 +86229,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.4,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/linter.rs",
@@ -85640,9 +86591,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/logic_part2_incl2.rs",
@@ -85791,7 +86742,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/mod.rs",
@@ -85862,7 +86813,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/modes.rs",
@@ -86099,7 +87050,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.32628,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier.rs",
@@ -86186,7 +87137,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier_transforms.rs",
@@ -86257,7 +87208,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.9,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/purifier_transforms_gen.rs",
@@ -86336,7 +87287,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/state.rs",
@@ -86407,7 +87358,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/repl/state_cont.rs",
@@ -86548,7 +87499,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 95.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/mod.rs",
@@ -86627,7 +87578,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 83.1,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser.rs",
@@ -86714,7 +87665,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.3,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_convert.rs",
@@ -86801,7 +87752,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 84.9,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_convert_2.rs",
@@ -86967,7 +87918,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 86.720215,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests3.rs",
@@ -87062,7 +88013,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 88.94832,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests4.rs",
@@ -87157,7 +88108,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.61255,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests5.rs",
@@ -87236,7 +88187,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.71154,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_coverage_tests5_counter.rs",
@@ -87313,9 +88264,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_part2_incl2.rs",
@@ -87377,7 +88328,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 81.6,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/parser_string.rs",
@@ -87464,7 +88415,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.79876,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/services/tests.rs",
@@ -87543,7 +88494,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/stdlib.rs",
@@ -87772,7 +88723,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/test_generator/coverage.rs",
@@ -87938,7 +88889,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/test_generator/mod.rs",
@@ -88087,7 +89038,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.8,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/boundary.rs",
@@ -88174,7 +89125,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/coverage.rs",
@@ -88245,7 +89196,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/cross_validation.rs",
@@ -88316,7 +89267,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.03226,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/error_injection.rs",
@@ -88354,8 +89305,9 @@
             "issue": "High cyclomatic complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 1,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -88490,7 +89442,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.46477,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/testing/stress.rs",
@@ -88520,8 +89472,9 @@
             "issue": "High cognitive complexity: 33"
           }
         ],
-        "critical_defects_count": 0,
-        "has_critical_defects": false,
+        "critical_defects_count": 6,
+        "has_critical_defects": true,
+        "critical_defects_suppressed": "file is not tracked by git; critical-defect auto-fail is not                      applied to code with no history (#279)",
         "has_contract_coverage": false
       },
       "components": {
@@ -88577,7 +89530,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/buffer.rs",
@@ -88648,7 +89601,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.74419,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/events.rs",
@@ -88814,7 +89767,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tracing/mod.rs",
@@ -89034,7 +89987,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.7,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/app.rs",
@@ -89121,7 +90074,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/events.rs",
@@ -89192,7 +90145,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 95.818184,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/mod.rs",
@@ -89271,7 +90224,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/tui/panels.rs",
@@ -89421,7 +90374,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/types/mod.rs",
@@ -89562,7 +90515,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/mod.rs",
@@ -89633,7 +90586,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 80.0,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/pipeline.rs",
@@ -89894,7 +90847,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.57445,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/validation/rules.rs",
@@ -90060,7 +91013,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/kani_harnesses.rs",
@@ -90131,7 +91084,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/mod.rs",
@@ -90202,7 +91155,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.7,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/properties.rs",
@@ -90289,7 +91242,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.46154,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/src/verifier/tests.rs",
@@ -90534,7 +91487,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.645485,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_dockerfile_integration.rs",
@@ -90613,7 +91566,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.82869,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_dockerfile_purify.rs",
@@ -90692,7 +91645,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.811325,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_integration.rs",
@@ -90771,7 +91724,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.67316,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_make_formatting.rs",
@@ -90850,7 +91803,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.96403,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/cli_make_lint.rs",
@@ -91008,7 +91961,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 96.81967,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/falsification_probar_testing.rs",
@@ -91095,7 +92048,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/golden_trace.rs",
@@ -91245,7 +92198,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.71544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/linter_bug_hunting.rs",
@@ -91498,7 +92451,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/linter_tui_bug_hunting_hunt.rs",
@@ -91569,7 +92522,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.7541,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/makefile_false_positives_fix.rs",
@@ -91885,7 +92838,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/parse_performance.rs",
@@ -92043,7 +92996,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.70348,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/parser_probar_testing.rs",
@@ -92209,7 +93162,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.292595,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/property_dockerfile_purify.rs",
@@ -92296,7 +93249,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.51958,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/property_fix_safety.rs",
@@ -92533,7 +93486,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.864334,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/simulation_probar_testing.rs",
@@ -92620,7 +93573,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.608696,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/stdlib_extended_test.rs",
@@ -92857,7 +93810,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.26165,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_fix_safety_taxonomy.rs",
@@ -93094,7 +94047,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 97.27273,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_005_lint_integration.rs",
@@ -93244,7 +94197,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.8125,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_010_dockerfile_scoring.rs",
@@ -93323,7 +94276,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 99.34599,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_issue_016_makefile_false_positives.rs",
@@ -93402,7 +94355,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.0,
         "total": 99.09091,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_003_002_cli.rs",
@@ -93552,7 +94505,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_explain_mode.rs",
@@ -93623,7 +94576,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 95.28926,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/test_repl_mode_based_processing.rs",
@@ -94018,7 +94971,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 98.975746,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash/tests/transpiler_bug_hunting.rs",
@@ -94348,9 +95301,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/generated_contracts.rs",
@@ -94586,7 +95539,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/handlers/mod.rs",
@@ -94727,7 +95680,7 @@
         "consistency_score": 10.0,
         "entropy_score": 8.5,
         "total": 98.63637,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-mcp/src/main.rs",
@@ -94798,7 +95751,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/build.rs",
@@ -94875,9 +95828,9 @@
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
-        "entropy_score": 0.0,
+        "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/src/generated_contracts.rs",
@@ -94939,7 +95892,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./rash-runtime/src/lib.rs",
@@ -95001,7 +95954,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 66.92609,
-        "grade": "CPlus",
+        "grade": "C+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./scripts/split_registry.py",
@@ -95112,7 +96065,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.16867,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/generated_contracts.rs",
@@ -95191,7 +96144,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/lib.rs",
@@ -95253,7 +96206,7 @@
         "consistency_score": 10.0,
         "entropy_score": 6.5,
         "total": 96.81818,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./src/verification_specs.rs",
@@ -95403,7 +96356,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/sandbox.rs",
@@ -95474,7 +96427,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 97.994354,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/shellcheck_validation.rs",
@@ -95553,7 +96506,7 @@
         "consistency_score": 10.0,
         "entropy_score": 9.5,
         "total": 99.545456,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/integration/simple.rs",
@@ -95703,7 +96656,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_create.rs",
@@ -95774,7 +96727,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_get.rs",
@@ -95845,7 +96798,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.0,
         "total": 95.454544,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/nodejs_project_bootstrap_setup.rs",
@@ -95916,7 +96869,7 @@
         "consistency_score": 10.0,
         "entropy_score": 10.0,
         "total": 100.0,
-        "grade": "APlus",
+        "grade": "A+",
         "confidence": 1.0,
         "language": "Rust",
         "file_path": "./tests/open_source/python_project_bootstrap_more.rs",
@@ -96223,7 +97176,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.5,
         "total": 83.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/canary_pytorch.py",
@@ -96326,7 +97279,7 @@
         "consistency_score": 10.0,
         "entropy_score": 7.0,
         "total": 84.5,
-        "grade": "BPlus",
+        "grade": "B+",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/eval_canary.py",
@@ -96413,7 +97366,7 @@
         "consistency_score": 10.0,
         "entropy_score": 5.5,
         "total": 87.93909,
-        "grade": "AMinus",
+        "grade": "A-",
         "confidence": 0.95,
         "language": "Python",
         "file_path": "./training/evaluate_chat.py",
@@ -96624,19 +97577,19 @@
     }
   },
   "summary": {
-    "total_files": 1229,
-    "avg_score": 95.05844,
+    "total_files": 1237,
+    "avg_score": 95.03782,
     "grade_distribution": {
-      "APlus": 635,
-      "A": 517,
-      "AMinus": 33,
-      "BPlus": 32,
+      "A+": 636,
+      "A": 524,
+      "A-": 33,
+      "B+": 32,
       "B": 11,
-      "CPlus": 1
+      "C+": 1
     },
     "languages": {
       "Python": 7,
-      "Rust": 1221,
+      "Rust": 1229,
       "TypeScript": 1
     }
   }

--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.30.0",
-  "created_at": "2026-08-11T18:07:12.916864083Z",
+  "created_at": "2026-08-11T18:07:44.329591114Z",
   "git_context": null,
   "files": {
     "./bashrs-oracle/benches/classification.rs": {

--- a/rash/src/cli/lint_commands.rs
+++ b/rash/src/cli/lint_commands.rs
@@ -200,7 +200,13 @@ fn lint_single_file(input: &Path, opts: &LintCommandOptions<'_>) -> Result<()> {
         emit_ci_annotations(input, &result);
         exit_for_fail_on(&result, opts.fail_on)
     } else {
-        output_lint_results(&result, opts.format, input)
+        // GH-209: print, THEN apply the --fail-on threshold. Previously this
+        // called a variant that picked the exit code itself, so --fail-on was
+        // honoured only under --ci and `bashrs lint --fail-on error Makefile`
+        // still exited 1 on a warnings-only run. Default is Warning, so the
+        // out-of-the-box exit codes are unchanged.
+        output_lint_results_no_exit(&result, opts.format, input)?;
+        exit_for_fail_on(&result, opts.fail_on)
     }
 }
 

--- a/rash/src/cli/lint_commands_build.rs
+++ b/rash/src/cli/lint_commands_build.rs
@@ -143,34 +143,17 @@ pub(crate) fn handle_lint_fixes(
     }
 }
 
-/// Display lint results and exit with the appropriate code.
-pub(crate) fn output_lint_results(
-    result: &crate::linter::LintResult,
-    format: LintFormat,
-    input: &Path,
-) -> Result<()> {
-    use crate::linter::output::write_results;
+// GH-209: `output_lint_results` used to live here and chose the exit code
+// itself — `has_warnings() -> exit(1)` — with no knowledge of `--fail-on`.
+// Since it was the ONLY path for a single file outside `--ci` mode, the
+// documented `--fail-on error` flag did nothing for the most common invocation
+// (`bashrs lint Makefile`), and a warnings-only run still exited 1. It is
+// removed rather than taught about `--fail-on`, so no caller can reintroduce
+// an exit decision that bypasses the threshold: printing and exiting are now
+// separate, and `exit_for_fail_on` is the single place that decides.
 
-    let output_format = super::convert_lint_format(format);
-    let file_path = input.to_str().unwrap_or("unknown");
-    write_results(&mut std::io::stdout(), result, output_format, file_path)
-        .map_err(|e| Error::Internal(format!("Failed to write lint results: {e}")))?;
-
-    // Exit with appropriate code (Issue #6)
-    // Exit 0: No issues
-    // Exit 1: Warnings found
-    // Exit 2: Errors found
-    if result.has_errors() {
-        std::process::exit(2);
-    } else if result.has_warnings() {
-        std::process::exit(1);
-    }
-
-    Ok(())
-}
-
-/// Display lint results without calling process::exit (for multi-file aggregation).
-fn output_lint_results_no_exit(
+/// Display lint results without calling process::exit.
+pub(crate) fn output_lint_results_no_exit(
     result: &crate::linter::LintResult,
     format: LintFormat,
     input: &Path,

--- a/rash/src/linter/heredoc.rs
+++ b/rash/src/linter/heredoc.rs
@@ -123,7 +123,10 @@ mod tests {
         assert!(r.contains(&4), "python line 4 must be inside the region");
         assert!(!r.contains(&2), "the opening line is real shell");
         assert!(!r.contains(&5), "the terminator is not body");
-        assert!(!r.contains(&6), "code after the heredoc must still be linted");
+        assert!(
+            !r.contains(&6),
+            "code after the heredoc must still be linted"
+        );
     }
 
     #[test]
@@ -155,7 +158,10 @@ mod tests {
         let src = "cat <<'DOC'\nexample: cat <<'INNER'\nDOC\necho after\n";
         let r = quoted_heredoc_lines(src);
         assert!(r.contains(&2), "the doc line is body");
-        assert!(!r.contains(&4), "code after the outer heredoc is still linted");
+        assert!(
+            !r.contains(&4),
+            "code after the outer heredoc is still linted"
+        );
     }
 
     #[test]

--- a/rash/src/linter/heredoc.rs
+++ b/rash/src/linter/heredoc.rs
@@ -1,0 +1,169 @@
+//! Heredoc region scanning, shared by every lint rule.
+//!
+//! GH-217: the rules see a flat stream of physical lines with no notion of
+//! heredoc regions, so any line-oriented rule fires *inside* heredoc bodies. A
+//! **quoted** heredoc body (`<<'EOF'` / `<<"EOF"`) is literal text by
+//! definition — that is the entire point of quoting the delimiter — so shell
+//! rules must not analyse it. Embedding Python, awk or jq that way is a common
+//! idiom, and `SC1007` is `Severity::Error`, so the false positives block
+//! commits.
+//!
+//! This lives in shared scanning code rather than in individual rules on
+//! purpose. `sc2006` already had a private copy of this logic (issue #96) and
+//! the other 384 rules did not, which is precisely how GH-217 happened: a
+//! per-rule fix cannot generalise, and the next line-oriented rule would have
+//! reintroduced the bug. Applying it once, where diagnostics are aggregated,
+//! covers every rule that exists and every rule not yet written.
+//!
+//! **Unquoted heredocs are deliberately NOT skipped.** Their bodies undergo
+//! parameter expansion and command substitution, so they really are shell and
+//! rules like SC2006 should still fire there.
+
+use std::collections::HashSet;
+
+/// Parse the opening delimiter of a quoted heredoc, if this token starts one.
+///
+/// Returns the delimiter without quotes. Handles `<<'X'`, `<< 'X'`, `<<-'X'`
+/// and the double-quoted forms.
+fn parse_quoted_delimiter(rest: &str) -> Option<String> {
+    let rest = rest.strip_prefix('-').unwrap_or(rest);
+    let rest = rest.trim_start();
+    let quote = rest.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        // Unquoted heredoc: body IS expanded, so it is genuinely shell. Skip.
+        return None;
+    }
+    let after = &rest[quote.len_utf8()..];
+    let end = after.find(quote)?;
+    let delim = &after[..end];
+    if delim.is_empty() {
+        return None;
+    }
+    Some(delim.to_string())
+}
+
+/// Every `<<`-opener on a line, in order. A single command may open more than
+/// one (`cmd <<'A' <<'B'`), and POSIX consumes their bodies in that order.
+fn quoted_openers_on_line(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'<' && bytes[i + 1] == b'<' {
+            // `<<<` is a here-STRING, not a heredoc — it has no body.
+            if bytes.get(i + 2) == Some(&b'<') {
+                i += 3;
+                continue;
+            }
+            if let Some(delim) = parse_quoted_delimiter(&line[i + 2..]) {
+                out.push(delim);
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// 1-based line numbers that fall inside a **quoted** heredoc body.
+///
+/// The opening line itself is excluded — it is real shell and rules should
+/// still see it. The terminating delimiter line is excluded too.
+///
+/// Implemented as a state machine rather than "regex-match every line", because
+/// scanning every line for openers also matches openers that appear *inside* a
+/// body (e.g. a heredoc containing shell examples), which silently extends the
+/// suppressed region past where it should end.
+pub fn quoted_heredoc_lines(source: &str) -> HashSet<usize> {
+    let mut inside = HashSet::new();
+    let mut pending: Vec<String> = Vec::new();
+    let mut active: Option<String> = None;
+
+    for (idx, line) in source.lines().enumerate() {
+        let line_num = idx + 1;
+
+        if let Some(delim) = active.clone() {
+            // `<<-` permits a tab-indented terminator; trimming is the lenient
+            // reading and matches the previous behaviour in sc2006.
+            if line.trim() == delim {
+                // Terminator reached; a second opener from the same command
+                // (`cmd <<'A' <<'B'`) starts consuming immediately.
+                active = if pending.is_empty() {
+                    None
+                } else {
+                    Some(pending.remove(0))
+                };
+            } else {
+                inside.insert(line_num);
+            }
+            continue;
+        }
+
+        let mut openers = quoted_openers_on_line(line);
+        if !openers.is_empty() {
+            active = Some(openers.remove(0));
+            pending = openers;
+        }
+    }
+
+    inside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_python_body_is_a_region() {
+        // The exact reproduction from GH-217.
+        let src = "#!/bin/sh\npython3 - <<'PY'\np = 1\nq = 2\nPY\necho done\n";
+        let r = quoted_heredoc_lines(src);
+        assert!(r.contains(&3), "python line 3 must be inside the region");
+        assert!(r.contains(&4), "python line 4 must be inside the region");
+        assert!(!r.contains(&2), "the opening line is real shell");
+        assert!(!r.contains(&5), "the terminator is not body");
+        assert!(!r.contains(&6), "code after the heredoc must still be linted");
+    }
+
+    #[test]
+    fn unquoted_heredoc_is_not_a_region() {
+        // Body IS expanded, so it is shell and rules must still fire.
+        let src = "cat <<EOF\n`date`\nEOF\n";
+        assert!(quoted_heredoc_lines(src).is_empty());
+    }
+
+    #[test]
+    fn double_quoted_and_dash_forms() {
+        let src = "cat <<-\"EOF\"\n\tbody\n\tEOF\nafter\n";
+        let r = quoted_heredoc_lines(src);
+        assert!(r.contains(&2));
+        assert!(!r.contains(&4));
+    }
+
+    #[test]
+    fn here_string_has_no_body() {
+        let src = "cat <<<'literal'\necho after\n";
+        assert!(quoted_heredoc_lines(src).is_empty());
+    }
+
+    #[test]
+    fn opener_inside_a_body_does_not_extend_the_region() {
+        // A heredoc whose body documents another heredoc. The naive
+        // scan-every-line approach treats line 2 as a new opener and swallows
+        // everything after it.
+        let src = "cat <<'DOC'\nexample: cat <<'INNER'\nDOC\necho after\n";
+        let r = quoted_heredoc_lines(src);
+        assert!(r.contains(&2), "the doc line is body");
+        assert!(!r.contains(&4), "code after the outer heredoc is still linted");
+    }
+
+    #[test]
+    fn two_heredocs_on_one_line_consume_bodies_in_order() {
+        let src = "diff <<'A' <<'B'\na1\nA\nb1\nB\nafter\n";
+        let r = quoted_heredoc_lines(src);
+        assert!(r.contains(&2), "first body");
+        assert!(r.contains(&4), "second body");
+        assert!(!r.contains(&6), "code after both is linted");
+    }
+}

--- a/rash/src/linter/mod.rs
+++ b/rash/src/linter/mod.rs
@@ -23,6 +23,8 @@ pub mod citl;
 pub mod diagnostic;
 pub mod docker_profiler;
 pub mod embedded;
+/// Heredoc region scanning shared by all rules (GH-217)
+pub mod heredoc;
 pub mod ignore_file;
 pub mod make_preprocess;
 pub mod output;

--- a/rash/src/linter/rules/make003.rs
+++ b/rash/src/linter/rules/make003.rs
@@ -131,6 +131,33 @@ fn check_unquoted_vars(line: &str, line_num: usize, result: &mut LintResult) {
         }
 
         if chars[i] == '$' && i + 1 < chars.len() {
+            // GH-209: `$$` is Make's escape for a literal `$`; the shell (or an
+            // embedded awk/perl program) receives a single `$`, so it is NOT a
+            // Make variable and must not be parsed as one.
+            //
+            // Previously `parse_variable_reference` fell into its `$VAR` branch,
+            // scanned zero alphanumerics because the next char is `$`, and
+            // emitted a diagnostic spanning one character whose autofix was
+            // `"$"` — replacing Make's escape with a quoted dollar, which
+            // changes what the shell receives. The canonical trigger is the
+            // self-documenting-help idiom present in most Makefiles:
+            //
+            //     @awk '… { printf "  %-12s %s\n", $$1, $$2 }' "$(MAKEFILE_LIST)"
+            //
+            // where `$$1`/`$$2` are awk FIELD references, not variables to
+            // quote — quoting them breaks the awk program.
+            //
+            // Both characters are consumed. Whatever follows is shell-level
+            // (`$1`, `$TMPDIR`), and deciding whether THAT wants quoting needs
+            // to know if it sits inside an embedded awk/perl/jq program. This
+            // rule cannot know that, and guessing produced an autofix users
+            // could not apply — so it stays silent here rather than emit advice
+            // that is wrong in the common case.
+            if chars[i + 1] == '$' {
+                i += 2;
+                continue;
+            }
+
             // F037 FIX: If we're inside a quoted string, skip this variable
             if in_double_quote || in_single_quote {
                 i += 1;
@@ -282,4 +309,38 @@ mod tests {
             result.diagnostics
         );
     }
+
+    /// GH-209: `$$` is Make's escape for a literal `$`. The self-documenting
+    /// help idiom passes `$$1`/`$$2` to awk as FIELD references; the old code
+    /// emitted a one-char diagnostic whose fix was `"$"`.
+    #[test]
+    fn gh209_make_escaped_dollar_is_not_a_variable() {
+        // UNQUOTED on purpose. The awk-in-single-quotes form from the issue is
+        // already skipped by the quote tracking above, so a test using it would
+        // pass with or without this fix — vacuous. Outside quotes is where the
+        // old code fell into its `$VAR` branch, scanned zero alphanumerics
+        // because the next char is `$`, and emitted a one-character diagnostic
+        // whose autofix was `"$"`.
+        let src = "clean:\n\trm -rf $$1\n";
+        let result = check(src);
+        assert!(
+            result.diagnostics.is_empty(),
+            "GH-209: $$ is Make's escape for a literal $, not an unquoted variable. Got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    /// The escape must not blind the rule to a genuinely unquoted variable
+    /// elsewhere on the same line — otherwise the fix trades a false positive
+    /// for a false negative.
+    #[test]
+    fn gh209_escape_does_not_suppress_a_real_finding_on_the_same_line() {
+        let src = "clean:\n\t@awk '{print $$1}'; rm -rf $(BUILD_DIR)\n";
+        let result = check(src);
+        assert!(
+            !result.diagnostics.is_empty(),
+            "an unquoted $(BUILD_DIR) must still be reported alongside $$1"
+        );
+    }
+
 }

--- a/rash/src/linter/rules/make010.rs
+++ b/rash/src/linter/rules/make010.rs
@@ -81,8 +81,43 @@ pub fn check(source: &str) -> LintResult {
 }
 
 /// Check if a recipe line already has error handling
+/// GH-209: this used to be a substring test for the literal `"|| exit"`, so the
+/// compound form
+///
+/// ```make
+/// curl -fsSL "$(URL)" | tar xz || { echo "✗ download failed"; exit 1; }
+/// ```
+///
+/// was reported as missing error handling — even though it handles errors
+/// strictly better than a bare `|| exit 1`, since the user learns what failed.
+/// The offered autofix appended a second `|| exit 1` after a block that already
+/// exits, which is dead code.
+///
+/// Now: find the `||` and inspect its tail, so any failure branch that
+/// terminates counts — `|| exit 1`, `|| { …; exit 1; }`, `|| return 1`, and the
+/// common `die`/`fail`/`abort` helpers.
 fn has_error_handling(recipe: &str) -> bool {
-    recipe.contains("|| exit") || recipe.contains("set -e") || recipe.contains("&&")
+    if recipe.contains("set -e") || recipe.contains("&&") {
+        return true;
+    }
+
+    let Some(idx) = recipe.find("||") else {
+        return false;
+    };
+    let tail = &recipe[idx + 2..];
+
+    if tail.contains("exit") || tail.contains("return") {
+        return true;
+    }
+
+    // `|| die "msg"` and `|| { fail …` — the brace may be its own token
+    // (`|| { fail`) or glued on (`||{fail`), so strip it before the first word
+    // rather than from it.
+    tail.trim_start()
+        .trim_start_matches('{')
+        .split_whitespace()
+        .next()
+        .is_some_and(|w| matches!(w, "die" | "fail" | "abort" | "error" | "bail"))
 }
 
 /// Find if the recipe contains a critical command
@@ -413,4 +448,28 @@ mod tests {
             }
         }
     }
+
+    /// GH-209: `|| { echo ...; exit 1; }` IS error handling — better than a bare
+    /// `|| exit 1`. The old substring test for the literal "|| exit" missed it,
+    /// and the autofix appended a second `|| exit 1` after a block that exits.
+    #[test]
+    fn gh209_compound_error_handler_is_recognized() {
+        assert!(has_error_handling(
+            "curl -fsSL \"$(URL)\" | tar xz || { echo \"failed\"; exit 1; }"
+        ));
+        assert!(has_error_handling("rm -rf \"$(DIR)\" || { echo \"rm failed\"; exit 1; }"));
+        assert!(has_error_handling("cmd || return 1"));
+        assert!(has_error_handling("cmd || die \"nope\""));
+        assert!(has_error_handling("cmd || { fail \"nope\"; }"));
+    }
+
+    /// And a recipe with NO handling must still be reported, or the fix is a
+    /// false negative rather than a fix.
+    #[test]
+    fn gh209_unhandled_command_still_reported() {
+        assert!(!has_error_handling("curl -fsSL \"$(URL)\" | tar xz"));
+        let result = check("target:\n\tcurl -fsSL \"$(URL)\" | tar xz\n");
+        assert!(!result.diagnostics.is_empty(), "genuinely unhandled curl must still fire");
+    }
+
 }

--- a/rash/src/linter/rules/make016.rs
+++ b/rash/src/linter/rules/make016.rs
@@ -1,272 +1,77 @@
-//! MAKE016: Unquoted variable in prerequisites
+//! MAKE016: retired — Make does not quote prerequisites (GH-209)
 //!
-//! **Rule**: Detect unquoted variables in target prerequisites
+//! This rule used to flag `$(VAR)` in a target's prerequisite list and offer to
+//! quote it. **That advice is not merely useless, it breaks the build.**
 //!
-//! **Why this matters**:
-//! Variables in prerequisites should be quoted to handle filenames with spaces.
-//! Unquoted variables like `$(FILES)` will break if any filename contains spaces.
-//! GNU Make doesn't automatically quote variable expansions, so this must be
-//! done explicitly. This is especially important for `$(wildcard)` results.
+//! GNU Make's prerequisite list is whitespace-separated and performs no
+//! shell-style quote removal. A target line
 //!
-//! **Auto-fix**: Add quotes around variable references in prerequisites
-//!
-//! ## Examples
-//!
-//! ❌ **BAD** (unquoted variable - breaks with spaces):
 //! ```makefile
-//! app: $(FILES)
-//! \t$(CC) $(FILES) -o app
+//! sakila: "$(SAKILA_DIR)"/sakila-data.sql
 //! ```
 //!
-//! ✅ **GOOD** (quoted variable - handles spaces):
-//! ```makefile
-//! app: "$(FILES)"
-//! \t$(CC) "$(FILES)" -o app
-//! ```
+//! asks Make for a file whose name literally begins with a double-quote
+//! character. The build then fails with "No rule to make target", and the
+//! failure points at the prerequisite rather than at the linter that
+//! introduced it.
+//!
+//! The rule's own doc-comment carried the broken form as its ✅ GOOD example,
+//! so the premise was wrong from the first commit rather than drifting later.
+//!
+//! ## Why it is silenced rather than corrected
+//!
+//! There is no correct version of "quote this prerequisite". The conventional
+//! Make answer to spaces in filenames is to avoid them, or to escape at the
+//! variable level with `$(subst …)` — never quoting in the prerequisite list.
+//! Recipes are shell and prerequisites are not, and only the former can be
+//! linted this way. Unquoted variables in *recipe* lines are already MAKE003's
+//! job, so repurposing this rule there would only duplicate it.
+//!
+//! ## Why the module still exists
+//!
+//! The ID stays registered so `--ignore MAKE016` in an existing config keeps
+//! parsing, and so this explanation lives where the next person looks. `check`
+//! is intentionally total: it returns no diagnostics for any input.
+//!
+//! Reported by a user whose CI ultimately **dropped the `bashrs lint Makefile`
+//! step entirely** because no combination of applied fixes could get a correct
+//! Makefile to exit 0. A rule that cannot be satisfied trains people to remove
+//! the linter.
 
-use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
+use crate::linter::LintResult;
 
-/// Check for unquoted variables in prerequisites
-pub fn check(source: &str) -> LintResult {
-    let mut result = LintResult::new();
-
-    for (line_num, line) in source.lines().enumerate() {
-        // Skip comment lines
-        if line.trim_start().starts_with('#') {
-            continue;
-        }
-
-        // Skip non-target lines (must contain ':')
-        if !is_target_line(line) {
-            continue;
-        }
-
-        // Extract prerequisites part (after ':')
-        if let Some(prerequisites) = extract_prerequisites(line) {
-            // Find all unquoted variables in prerequisites
-            let unquoted_vars = find_unquoted_variables(&prerequisites);
-
-            for var in unquoted_vars {
-                let span = Span::new(line_num + 1, 1, line_num + 1, line.len());
-                let fix_replacement = create_fix(line, &var);
-
-                let diag = Diagnostic::new(
-                    "MAKE016",
-                    Severity::Warning,
-                    format!("Unquoted variable '{}' in prerequisites - may break with spaces in filenames", var),
-                    span,
-                )
-                .with_fix(Fix::new(&fix_replacement));
-
-                result.add(diag);
-            }
-        }
-    }
-
-    result
-}
-
-/// Check if line is a target line (contains ':' and not a recipe)
-fn is_target_line(line: &str) -> bool {
-    line.contains(':') && !line.starts_with('\t')
-}
-
-/// Extract prerequisites part from target line (everything after ':')
-fn extract_prerequisites(line: &str) -> Option<String> {
-    if let Some(colon_pos) = line.find(':') {
-        let prereqs = line[colon_pos + 1..].trim();
-        if !prereqs.is_empty() {
-            return Some(prereqs.to_string());
-        }
-    }
-    None
-}
-
-/// Find all unquoted variables in prerequisites
-/// Returns variable references like "$(FILES)" that are not already quoted
-fn find_unquoted_variables(prerequisites: &str) -> Vec<String> {
-    let mut vars = Vec::new();
-    let mut chars = prerequisites.chars().peekable();
-    let mut in_quote = false;
-    let mut pos = 0;
-
-    while let Some(ch) = chars.next() {
-        match ch {
-            '"' => in_quote = !in_quote,
-            '$' if !in_quote => {
-                collect_unquoted_var_at(prerequisites, pos, &mut chars, &mut vars);
-            }
-            _ => {}
-        }
-        pos += ch.len_utf8();
-    }
-
-    vars
-}
-
-/// Check if the current position starts a variable reference and collect it
-fn collect_unquoted_var_at(
-    source: &str,
-    pos: usize,
-    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
-    vars: &mut Vec<String>,
-) {
-    if let Some(&next_ch) = chars.peek() {
-        if next_ch == '(' || next_ch == '{' {
-            if let Some(var) = extract_variable_ref(&source[pos..]) {
-                if !is_automatic_variable(&var) {
-                    vars.push(var);
-                }
-            }
-        }
-    }
-}
-
-/// Extract a variable reference starting at position (e.g., "$(FILES)")
-fn extract_variable_ref(s: &str) -> Option<String> {
-    if !s.starts_with("$(") && !s.starts_with("${") {
-        return None;
-    }
-
-    let close_char = if s.starts_with("$(") { ')' } else { '}' };
-    if let Some(close_pos) = s.find(close_char) {
-        return Some(s[..=close_pos].to_string());
-    }
-
-    None
-}
-
-/// Check if a variable is an automatic variable ($@, $<, $^, $?, $*, $+)
-fn is_automatic_variable(var: &str) -> bool {
-    let content = var
-        .trim_start_matches("$(")
-        .trim_start_matches("${")
-        .trim_end_matches(')')
-        .trim_end_matches('}');
-
-    // Automatic variables are single character
-    content.len() == 1
-        && matches!(
-            content.chars().next(),
-            Some('@' | '<' | '^' | '?' | '*' | '+')
-        )
-}
-
-/// Create a fix by adding quotes around the unquoted variable
-fn create_fix(line: &str, unquoted_var: &str) -> String {
-    // Replace first occurrence of unquoted variable with quoted version
-    line.replacen(unquoted_var, &format!("\"{}\"", unquoted_var), 1)
+/// Retired. Emits no diagnostics for any input — see the module docs.
+pub fn check(_source: &str) -> LintResult {
+    LintResult::new()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // RED PHASE: Write failing tests first
-
+    /// The exact shape from GH-209. The old rule fired here and its autofix
+    /// would have produced `sakila: "$(SAKILA_DIR)"/sakila-data.sql`, which
+    /// Make reads as a filename starting with `"`.
     #[test]
-    fn test_MAKE016_detects_unquoted_variable() {
-        let makefile = "app: $(FILES)\n\t$(CC) $(FILES) -o app";
-        let result = check(makefile);
-
-        assert_eq!(result.diagnostics.len(), 1);
-        let diag = &result.diagnostics[0];
-        assert_eq!(diag.code, "MAKE016");
-        assert_eq!(diag.severity, Severity::Warning);
-        assert!(
-            diag.message.to_lowercase().contains("variable")
-                || diag.message.to_lowercase().contains("quote")
-        );
+    fn parameterized_prerequisite_is_not_flagged() {
+        let src = "sakila: $(SAKILA_DIR)/sakila-data.sql wait\n\t@echo ok\n";
+        assert!(check(src).diagnostics.is_empty());
     }
 
     #[test]
-    fn test_MAKE016_detects_wildcard_variable() {
-        let makefile = "app: $(wildcard *.c)\n\t$(CC) $^ -o app";
-        let result = check(makefile);
-
-        // $(wildcard) in prerequisites should be quoted
-        assert_eq!(result.diagnostics.len(), 1);
-    }
-
-    #[test]
-    fn test_MAKE016_detects_multiple_variables() {
-        let makefile = "app: $(SOURCES) $(HEADERS)\n\t$(CC) $^ -o app";
-        let result = check(makefile);
-
-        // Two unquoted variables
-        assert_eq!(result.diagnostics.len(), 2);
-    }
-
-    #[test]
-    fn test_MAKE016_provides_fix() {
-        let makefile = "app: $(FILES)\n\t$(CC) $(FILES) -o app";
-        let result = check(makefile);
-
-        assert!(result.diagnostics[0].fix.is_some());
-        let fix = result.diagnostics[0].fix.as_ref().unwrap();
-        // Fix should add quotes
-        assert!(fix.replacement.contains("\"$(FILES)\""));
-    }
-
-    #[test]
-    fn test_MAKE016_no_warning_for_quoted_variables() {
-        let makefile = "app: \"$(FILES)\"\n\t$(CC) \"$(FILES)\" -o app";
-        let result = check(makefile);
-
-        // Quoted variables are OK
-        assert_eq!(result.diagnostics.len(), 0);
-    }
-
-    #[test]
-    fn test_MAKE016_no_warning_for_simple_targets() {
-        let makefile = "app: main.c utils.c\n\t$(CC) $^ -o app";
-        let result = check(makefile);
-
-        // No variables in prerequisites - OK
-        assert_eq!(result.diagnostics.len(), 0);
-    }
-
-    #[test]
-    fn test_MAKE016_no_warning_for_automatic_variables() {
-        let makefile = "%.o: %.c\n\t$(CC) -c $< -o $@";
-        let result = check(makefile);
-
-        // Automatic variables ($<, $@, $^) don't need quotes in prerequisites
-        assert_eq!(result.diagnostics.len(), 0);
-    }
-
-    #[test]
-    fn test_MAKE016_empty_makefile() {
-        let makefile = "";
-        let result = check(makefile);
-
-        assert_eq!(result.diagnostics.len(), 0);
-    }
-
-    #[test]
-    fn test_MAKE016_no_warning_for_variables_in_comments() {
-        // Comments should be completely ignored, even if they contain $(VAR) patterns
-        let makefile = r#"# MAKE016 (2 warnings): Unquoted $(MAKE) variable in comments - not applicable
-# Cannot quote variables in comments
-app: $(FILES)
-	$(CC) $^ -o app"#;
-        let result = check(makefile);
-
-        // Should only warn about $(FILES) in actual target line, not in comments
-        assert_eq!(
-            result.diagnostics.len(),
-            1,
-            "Should ignore variables in comments"
-        );
-        assert!(result.diagnostics[0].message.contains("$(FILES)"));
-    }
-
-    #[test]
-    fn test_MAKE016_ignores_comment_only_lines() {
-        let makefile = "# target: $(DEPS)\n# This is documentation\napp: actual_file\n\tgcc app.c";
-        let result = check(makefile);
-
-        // No warnings - comments are ignored
-        assert_eq!(result.diagnostics.len(), 0);
+    fn no_diagnostics_for_any_target_shape() {
+        for src in [
+            "app: $(FILES)\n",
+            "app: $(wildcard src/*.c)\n",
+            "%.o: %.c\n",
+            ".PHONY: all\n",
+            "all:\n",
+            "",
+        ] {
+            assert!(
+                check(src).diagnostics.is_empty(),
+                "MAKE016 must stay silent, got diagnostics for {src:?}"
+            );
+        }
     }
 }

--- a/rash/src/linter/rules/mod_lint_2.rs
+++ b/rash/src/linter/rules/mod_lint_2.rs
@@ -370,6 +370,22 @@ fn lint_shell_filtered(
     apply_rule!("REL004", rel004::check);
     apply_rule!("REL005", rel005::check);
 
+    // GH-217: drop diagnostics that land inside a QUOTED heredoc body. Such a
+    // body is literal text, not shell — that is what quoting the delimiter
+    // means — so every line-oriented rule was reporting on embedded Python,
+    // awk and jq. SC1007 is Severity::Error, so those false positives blocked
+    // commits.
+    //
+    // Filtered here, once, rather than in each rule: sc2006 carried a private
+    // copy of this logic (issue #96) and the other 384 rules did not, which is
+    // exactly how this recurred one rule at a time. Doing it at the point where
+    // diagnostics are aggregated covers every existing rule and every future
+    // one for free.
+    let heredoc_lines = crate::linter::heredoc::quoted_heredoc_lines(source);
+    result
+        .diagnostics
+        .retain(|diag| !heredoc_lines.contains(&diag.span.start_line));
+
     // Apply inline suppression filtering
     let suppression_manager = SuppressionManager::from_source(source);
     result

--- a/rash/src/linter/rules/sc2006.rs
+++ b/rash/src/linter/rules/sc2006.rs
@@ -28,8 +28,6 @@
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
 
-
-
 /// Regex to detect backtick command substitution: `command`
 #[allow(clippy::expect_used)] // Compile-time regex, panic on invalid pattern is acceptable
 static BACKTICK_PATTERN: std::sync::LazyLock<Regex> =

--- a/rash/src/linter/rules/sc2006.rs
+++ b/rash/src/linter/rules/sc2006.rs
@@ -27,19 +27,8 @@
 
 use crate::linter::{Diagnostic, Fix, LintResult, Severity, Span};
 use regex::Regex;
-use std::collections::HashSet;
 
-/// Regex to detect single-quoted heredoc: << 'DELIM' or <<- 'DELIM'
-#[allow(clippy::expect_used)] // Compile-time regex, panic on invalid pattern is acceptable
-static HEREDOC_SINGLE_QUOTED: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r"<<-?\s*'(\w+)'").expect("valid single-quoted heredoc regex")
-});
 
-/// Regex to detect double-quoted heredoc: << "DELIM" or <<- "DELIM"
-#[allow(clippy::expect_used)] // Compile-time regex, panic on invalid pattern is acceptable
-static HEREDOC_DOUBLE_QUOTED: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-    Regex::new(r#"<<-?\s*"(\w+)""#).expect("valid double-quoted heredoc regex")
-});
 
 /// Regex to detect backtick command substitution: `command`
 #[allow(clippy::expect_used)] // Compile-time regex, panic on invalid pattern is acceptable
@@ -55,46 +44,12 @@ static ASSIGNMENT_BACKTICK: std::sync::LazyLock<Regex> = std::sync::LazyLock::ne
     .expect("valid assignment backtick regex")
 });
 
-/// Collect line numbers inside a heredoc body (from start_idx+1 until delimiter is found)
-fn collect_heredoc_body_lines(
-    lines: &[&str],
-    start_idx: usize,
-    delimiter: &str,
-    quoted_lines: &mut HashSet<usize>,
-) {
-    for (inner_idx, inner_line) in lines.iter().enumerate().skip(start_idx + 1) {
-        if inner_line.trim() == delimiter {
-            break;
-        }
-        quoted_lines.insert(inner_idx + 1);
-    }
-}
-
-/// Issue #96: Parse heredoc regions and return line numbers inside quoted heredocs
-/// Quoted heredocs (single or double quoted delimiter) have literal content - no expansion
-fn get_quoted_heredoc_lines(source: &str) -> HashSet<usize> {
-    let mut quoted_lines = HashSet::new();
-    let lines: Vec<&str> = source.lines().collect();
-
-    for (idx, line) in lines.iter().enumerate() {
-        for pattern in &[&*HEREDOC_SINGLE_QUOTED, &*HEREDOC_DOUBLE_QUOTED] {
-            if let Some(caps) = pattern.captures(line) {
-                if let Some(delim) = caps.get(1) {
-                    collect_heredoc_body_lines(&lines, idx, delim.as_str(), &mut quoted_lines);
-                }
-            }
-        }
-    }
-
-    quoted_lines
-}
-
 /// Check for deprecated backtick command substitution
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
 
     // Issue #96: Get lines inside quoted heredocs (content is literal, not expanded)
-    let quoted_heredoc_lines = get_quoted_heredoc_lines(source);
+    let quoted_heredoc_lines = crate::linter::heredoc::quoted_heredoc_lines(source);
 
     for (line_num, line) in source.lines().enumerate() {
         let line_num = line_num + 1;


### PR DESCRIPTION
Closes #217. Closes #209.

Both issues have the same ending: a user turned `bashrs lint` **off**. #217 blocked commits via forjar's pre-commit hook; #209's reporter dropped the `bashrs lint Makefile` step from CI entirely after no combination of suggested fixes could make a correct Makefile exit 0.

A rule that cannot be satisfied doesn't get fixed — it gets removed.

---

## GH-217 — quoted heredoc bodies are not shell

```sh
python3 - <<'PY'
p = 1
q = 2
PY
```

`bash -n` accepts this. Published **6.66.2** reports 2 × `SC1007` — `Severity::Error`, so it blocks commits.

**Root cause is one level above the symptom.** The rules see a flat stream of physical lines with no notion of heredoc regions, so *any* line-oriented rule fires inside these bodies. SC1007 is just the one that got hit. (#211 was the same shape: `sc2188` iterating physical instead of logical lines.)

The machinery already existed and wasn't shared — `sc2006` carried a private `get_quoted_heredoc_lines` from issue #96; the other **384** rules had nothing. A per-rule fix can't generalise, so this is applied **once**, where diagnostics are aggregated. Every current and future rule inherits it. sc2006's copy is deleted, so there's one definition instead of two that can drift.

Written as a state machine, not the regex-per-line approach sc2006 used: scanning every line for openers also matches openers *inside* a body (a heredoc documenting a heredoc), silently extending the suppressed region past its end. There's a test for exactly that.

**Unquoted heredocs are deliberately still linted** — their bodies undergo expansion, so they really are shell.

---

## GH-209 — four Makefile defects

**1. `--fail-on` was ignored for the common invocation.** Single-file lint routed to `output_lint_results`, which picked the exit code itself (`has_warnings → exit 1`) and never saw `opts.fail_on`. The flag worked only under `--ci`. That function is **removed** rather than taught about the flag, so no caller can reintroduce an exit decision that bypasses the threshold. Default stays `Warning`; out-of-the-box exit codes are unchanged.

**2. MAKE003 read `$$` as a variable.** `$$` is Make's escape for a literal `$`. The parser fell into its `$VAR` branch, matched zero characters, and emitted a one-character diagnostic whose autofix was `"$"`. The trigger is the self-documenting-help idiom in most Makefiles, where `$$1`/`$$2` are **awk field references** — quoting them breaks the awk program.

**3. MAKE010 missed compound error handlers.** `has_error_handling` was a substring test for the literal `"|| exit"`, so `curl … || { echo "✗ failed"; exit 1; }` read as unhandled — though it's *better* than a bare `|| exit 1`. The autofix appended a **second** `|| exit 1` after a block that already exits.

**4. MAKE016's autofix broke the build.** It flagged `$(VAR)` in prerequisites and offered to quote it. GNU Make does no quote removal in prerequisite lists, so `sakila: "$(DIR)"/x.sql` asks for a file whose name literally starts with `"` — and the build then fails pointing at the prerequisite, not at the linter that wrote it. **The rule's own doc-comment carried the broken form as its ✅ GOOD example**, so the premise was wrong from the first commit. There is no correct version of "quote this prerequisite" — recipes are shell, prerequisites are not — so it's retired to a total no-op, ID still registered so existing `--ignore MAKE016` configs keep parsing.

---

## Verification

| | |
|---|---|
| RED, published 6.66.2 binary | 2 × SC1007 on valid shell |
| Targeted tests | **45 passed, 0 failed** (heredoc + make003/010/016 + existing property tests) |
| **Full suite** | **14,596 passed, 0 failed** |

The full suite is the one that mattered: a filter at the *aggregation* layer could have silently suppressed diagnostics hundreds of tests depend on. It didn't.

Every fix is paired with a test asserting the **true positive still fires**, so none of these trades a false positive for a false negative.

Two self-inflicted bugs caught before shipping, both worth noting:
- `|| { fail "x"; }` failed my own MAKE010 fix — `{` tokenises separately, so stripping the brace from the first word left an empty string.
- My first MAKE003 test was **vacuous**: `$$1` inside the awk single-quotes is already skipped by pre-existing quote tracking, so it would have passed with or without the fix. Moved outside quotes so it discriminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)