### PR TITLE
fix(kani): make the crate compile under cfg(kani), and stop swallowing the failure (GH-212)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,14 +560,63 @@ fuzz-trophies:
 verify: verify-kani verify-creusot verify-smt verify-model verify-properties
 	@echo "✅ All formal verification passed!"
 
+# GH-212: this target used to report success while proving NOTHING. The crate
+# had not compiled under cfg(kani) for months — 19 errors in its own harness
+# files — and every invocation was suffixed `|| true`, so the failure was
+# swallowed. Contracts declaring `kani_harnesses:` were undischarged the entire
+# time while the gate read green. `pv validate` passing meant the contract was
+# well-formed, not that its obligations held.
+#
+# Two outcomes are now distinguished, because they do not mean the same thing:
+#
+#   BUILD failure  -> HARD FAIL. This IS the GH-212 defect: a harness that does
+#                     not compile can never prove anything. Caught by
+#                     --only-codegen in ~106s, without invoking the solver.
+#   No convergence -> UNPROVEN. Reported loudly, non-fatal. Bounded model
+#                     checking is exponential; "did not finish in the budget" is
+#                     not "the property is false", and failing the build on it
+#                     would make `make verify` permanently red — which is how a
+#                     gate teaches people to bypass it.
+#
+# MEASURED 2026-08-11, kani 0.67.0, 32-core box: none of these harnesses
+# converge. CBMC spends its time inside alloc::raw_vec / Layout / LayoutError —
+# Rust's ALLOCATOR — because every harness calls an escaping function that
+# returns a heap String. Shrinking the input bound does not help: 8, 4 and 2
+# characters all time out, so string LENGTH was never the bottleneck. Proving
+# these properties needs the escapers refactored onto caller-provided &mut [u8]
+# buffers so no allocation is reachable from a harness. Tracked separately.
+KANI_TIMEOUT   ?= 300
+KANI_HARNESSES := verify_escape_safety verify_variable_expansion_safety verify_injection_safety
+
 verify-kani:
 	@echo "🔍 Running Kani model checker..."
-	@if cargo +nightly kani --version >/dev/null 2>&1; then \
-		cargo +nightly kani --harnesses verify_parser_soundness --unwind 10 || true; \
-		cargo +nightly kani --harnesses verify_escape_safety --unwind 10 || true; \
-		cargo +nightly kani --harnesses verify_injection_safety --unwind 10 || true; \
-	else \
+	@if ! cargo +nightly kani --version >/dev/null 2>&1; then \
 		echo "⚠️  Kani not installed, skipping bounded model checking"; \
+		exit 0; \
+	fi; \
+	echo "  [1/2] cfg(kani) build — GH-212 regression guard"; \
+	if ! cargo +nightly kani -p bashrs --only-codegen; then \
+		echo "❌ bashrs does not compile under cfg(kani): every harness is unrunnable,"; \
+		echo "   and every contract declaring kani_harnesses: is undischarged."; \
+		exit 1; \
+	fi; \
+	echo "  [2/2] solving — budget $(KANI_TIMEOUT)s per harness"; \
+	unproven=0; \
+	for h in $(KANI_HARNESSES); do \
+		timeout $(KANI_TIMEOUT) cargo +nightly kani -p bashrs --harness $$h >/dev/null 2>&1; \
+		rc=$$?; \
+		if [ $$rc -eq 0 ]; then \
+			echo "    ✅ $$h VERIFIED"; \
+		elif [ $$rc -eq 124 ]; then \
+			echo "    ⏱  $$h UNPROVEN — no convergence in $(KANI_TIMEOUT)s"; \
+			unproven=$$((unproven+1)); \
+		else \
+			echo "    ❌ $$h FAILED (exit $$rc) — a property was refuted"; \
+			exit 1; \
+		fi; \
+	done; \
+	if [ $$unproven -gt 0 ]; then \
+		echo "  ⚠️  kani: $$unproven/$(words $(KANI_HARNESSES)) unproven (allocator-bound; see the comment above this target)"; \
 	fi
 
 verify-creusot:

--- a/rash/src/formal/kani_harnesses.rs
+++ b/rash/src/formal/kani_harnesses.rs
@@ -7,14 +7,17 @@
 mod kani_proofs {
     use crate::formal::semantics::{posix_semantics, rash_semantics};
     use crate::formal::{AbstractState, FormalEmitter, TinyAst};
+    // GH-212: `let s: String = kani::any()` is an E0277 — String is not (and
+    // cannot be) kani::Arbitrary. These harnesses had never been compiled.
+    use crate::kani_bounded::{any_bounded_identifier, any_bounded_string};
 
     /// Verify that echo commands preserve their output exactly
     #[kani::proof]
+    #[kani::unwind(7)]
     fn verify_echo_semantic_equivalence() {
-        // Create a bounded string for the argument
-        let arg: String = kani::any();
-        kani::assume(arg.len() <= 10); // Bound the string length
-        kani::assume(arg.chars().all(|c| c.is_ascii_alphanumeric())); // Simple chars only
+        // Bounded at 6, not the original's 10: the state space is 62^N, and the
+        // bound must be justified by a measured runtime rather than a wish.
+        let arg = any_bounded_string::<6>();
 
         let ast = TinyAst::ExecuteCommand {
             command_name: "echo".to_string(),
@@ -48,21 +51,13 @@ mod kani_proofs {
 
     /// Verify that environment variable assignments are preserved
     #[kani::proof]
+    #[kani::unwind(6)]
     fn verify_assignment_semantic_equivalence() {
-        // Create bounded strings for name and value
-        let name: String = kani::any();
-        let value: String = kani::any();
-
-        // Bound the strings
-        kani::assume(name.len() > 0 && name.len() <= 8);
-        kani::assume(value.len() <= 10);
-
-        // Ensure valid variable name
-        kani::assume(name.chars().all(|c| c.is_ascii_alphabetic() || c == '_'));
-        kani::assume(
-            name.chars().next().unwrap().is_ascii_alphabetic()
-                || name.chars().next().unwrap() == '_',
-        );
+        // any_bounded_identifier encodes the leading-char rule the original
+        // spelled out with two assumes (and an `.unwrap()` on `next()` that
+        // would have been reachable had len == 0 slipped through).
+        let name = any_bounded_identifier::<4>();
+        let value = any_bounded_string::<5>();
 
         let ast = TinyAst::SetEnvironmentVariable {
             name: name.clone(),

--- a/rash/src/kani_bounded.rs
+++ b/rash/src/kani_bounded.rs
@@ -1,0 +1,54 @@
+#![cfg(kani)]
+//! Bounded symbolic values for Kani harnesses.
+//!
+//! Kani cannot generate a `String` or `&str`: neither implements
+//! `kani::Arbitrary`, and neither can — they are unbounded heap types, and
+//! bounded model checking needs a finite state space. Every `let s: String =
+//! kani::any();` in this repo was therefore an `E0277`, which is most of the 19
+//! errors that made the crate uncompilable under `cfg(kani)` (GH-212). Those
+//! harnesses had never been compiled, so nobody found out.
+//!
+//! The standard model is a fixed-size byte array (which IS `Arbitrary`) plus a
+//! symbolic length and an alphabet constraint. `N` is the real cost knob: the
+//! solver explores `|alphabet|^N` strings, so keep it small and raise it only
+//! with a measured runtime.
+
+/// A symbolic `String` of length `0..=N` over ASCII alphanumerics.
+///
+/// Pair with `#[kani::unwind(N + 1)]` on the harness — the loop below is what
+/// needs the unwind bound, and an unwind that is too low is reported by Kani as
+/// an unwinding-assertion failure rather than silently under-approximating.
+pub fn any_bounded_string<const N: usize>() -> String {
+    let bytes: [u8; N] = kani::any();
+    let len: usize = kani::any();
+    kani::assume(len <= N);
+
+    let mut s = String::with_capacity(len);
+    for &b in bytes.iter().take(len) {
+        kani::assume(b.is_ascii_alphanumeric());
+        s.push(b as char);
+    }
+    s
+}
+
+/// A symbolic POSIX-ish identifier of length `1..=N`: `[A-Za-z_][A-Za-z0-9_]*`.
+///
+/// Separate from `any_bounded_string` because the leading character carries a
+/// different constraint, and folding that into one function would either
+/// over-constrain ordinary strings or under-constrain identifiers.
+pub fn any_bounded_identifier<const N: usize>() -> String {
+    let bytes: [u8; N] = kani::any();
+    let len: usize = kani::any();
+    kani::assume(len >= 1 && len <= N);
+
+    let mut s = String::with_capacity(len);
+    for (i, &b) in bytes.iter().take(len).enumerate() {
+        if i == 0 {
+            kani::assume(b.is_ascii_alphabetic() || b == b'_');
+        } else {
+            kani::assume(b.is_ascii_alphanumeric() || b == b'_');
+        }
+        s.push(b as char);
+    }
+    s
+}

--- a/rash/src/lib.rs
+++ b/rash/src/lib.rs
@@ -113,6 +113,9 @@ pub mod gates;
 pub mod installer;
 /// Intermediate representation for transpilation
 pub mod ir;
+/// Bounded symbolic values for Kani harnesses (see GH-212)
+#[cfg(kani)]
+pub mod kani_bounded;
 /// Shell script linting with ShellCheck-equivalent rules
 pub mod linter;
 /// Makefile parsing and purification

--- a/rash/src/verifier/kani_harnesses.rs
+++ b/rash/src/verifier/kani_harnesses.rs
@@ -1,112 +1,106 @@
 #![cfg(kani)]
 //! Kani verification harnesses for RASH
 //!
-//! These harnesses verify critical safety properties using bounded model checking.
+//! These harnesses verify critical safety properties using bounded model
+//! checking.
+//!
+//! ## GH-212: this file did not compile
+//!
+//! Every harness here was written without ever being built — the crate has not
+//! compiled under `cfg(kani)` since these were added, and `make verify-kani`
+//! swallowed the failure with `|| true`. Repairing it surfaced three separate
+//! problems, only the first of which was a typo:
+//!
+//! 1. `kani::assert!` is not a macro Kani exports. Kani intercepts the standard
+//!    `assert!`/`assert_eq!`, which is what the harnesses should have used.
+//! 2. `escape_shell_value`, `is_valid_rust0` and `validate_rust0_ast` do not
+//!    exist in this crate and there is no evidence they ever did.
+//! 3. `String`/`&str` are not `kani::Arbitrary` and cannot be — see
+//!    `crate::kani_bounded`.
+//!
+//! Two harnesses were also removed rather than repaired, because compiling them
+//! would have produced proofs of nothing:
+//!
+//! - `verify_array_bounds_safety` asserted `true` on one branch and, on the
+//!   other, that `format!("if [ {} -lt {} ]; then", ..)` contains `"-lt"`. That
+//!   is a property of the format string literal. No code under test was reached.
+//! - `verify_parser_soundness` called the real parser on an arbitrary string and
+//!   checked it against the two functions that do not exist. Even with those
+//!   supplied, a full Rust parser over symbolic input is not tractable under
+//!   BMC; a passing version of it would only mean the bound was too small.
+//!
+//! A harness that cannot fail is worse than a missing one: it consumes the
+//! verification budget and reports success.
 
-use crate::ast::{Expr, Stmt, Type};
-use crate::emitter::escape::{escape_shell_string, escape_shell_value};
-use crate::services::parser;
-use crate::verifier::properties::{is_valid_rust0, validate_rust0_ast};
+use crate::emitter::escape::{escape_shell_string, escape_variable_name};
+use crate::kani_bounded::{any_bounded_identifier, any_bounded_string};
 
-/// Verify that the parser only accepts valid Rust₀ programs
+/// Verify shell string escaping prevents injection.
+///
+/// This is the one original harness that exercised production code, and it is
+/// kept as-is apart from the bounded input: `escape_shell_string` is the real
+/// function every emitted script depends on.
 #[kani::proof]
-#[kani::unwind(10)]
-fn verify_parser_soundness() {
-    let input: &str = kani::any();
-    kani::assume(input.len() < 1000); // Bound input for tractability
-
-    match parser::parse(input) {
-        Ok(ast) => {
-            // Property: Valid AST implies valid Rust₀
-            kani::assert!(validate_rust0_ast(&ast));
-        }
-        Err(_) => {
-            // Property: Parse error implies ∉ Rust₀
-            kani::assert!(!is_valid_rust0(input));
-        }
-    }
-}
-
-/// Verify shell string escaping prevents injection
-#[kani::proof]
-#[kani::unwind(20)]
+#[kani::unwind(3)]
 fn verify_escape_safety() {
-    let input: String = kani::any();
-    kani::assume(input.len() < 100);
+    let input = any_bounded_string::<2>();
 
     let escaped = escape_shell_string(&input);
 
-    // Property 1: Result is always single-quoted
-    kani::assert!(escaped.starts_with('\'') && escaped.ends_with('\''));
+    // Property 1: the result is always single-quoted
+    assert!(escaped.starts_with('\'') && escaped.ends_with('\''));
 
-    // Property 2: No unescaped metacharacters possible
-    kani::assert!(!contains_unescaped_metachar(&escaped));
+    // Property 2: no unescaped metacharacter can survive
+    assert!(!contains_unescaped_metachar(&escaped));
 
-    // Property 3: Original content is preserved (modulo escaping)
+    // Property 3: content is preserved modulo escaping (round-trip)
     let unescaped = unescape_shell_string(&escaped);
-    kani::assert!(unescaped == input);
+    assert!(unescaped == input);
 }
 
-/// Verify variable expansion is always safely quoted
+/// Verify that variable-name escaping accepts every valid identifier.
+///
+/// The original asserted that `format!("\"${{{}}}\"", name)` starts with `"` and
+/// contains `"${"` — true of the literal regardless of `name`, so it held even
+/// if `escape_variable_name` were the identity function. This calls the real
+/// `escape_variable_name` instead, which is what the emitter uses.
 #[kani::proof]
-#[kani::unwind(15)]
+#[kani::unwind(3)]
 fn verify_variable_expansion_safety() {
-    let var_name: String = kani::any();
-    kani::assume(var_name.len() < 50);
-    kani::assume(is_valid_identifier(&var_name));
+    let var_name = any_bounded_identifier::<2>();
 
-    let expansion = format!("\"${{{}}}\"", var_name);
+    let escaped = escape_variable_name(&var_name);
 
-    // Property: Variable expansion is always double-quoted
-    kani::assert!(expansion.starts_with('"') && expansion.ends_with('"'));
-    kani::assert!(expansion.contains("${") && expansion.contains("}"));
+    // A valid identifier must survive escaping unchanged — if it does not, the
+    // emitter is rewriting names the user chose.
+    assert!(escaped == var_name);
+
+    // And the expansion built from it is quoted, so word-splitting cannot occur.
+    let expansion = format!("\"${{{escaped}}}\"");
+    assert!(expansion.starts_with('"') && expansion.ends_with('"'));
+    assert!(!contains_unescaped_metachar(&escaped));
 }
 
-/// Verify injection safety for all emitted shell code
+/// Verify no injection is possible through an escaped argument.
+///
+/// The original called `escape_shell_value` (which does not exist) and checked
+/// the result with `can_inject_command`, a simplified re-implementation local to
+/// this file — so it verified a toy model against a toy oracle. This runs the
+/// real escaper and asserts the property directly on its output.
 #[kani::proof]
-#[kani::unwind(10)]
+#[kani::unwind(3)]
 fn verify_injection_safety() {
-    // Generate arbitrary user input that might contain malicious content
-    let user_input: String = kani::any();
-    kani::assume(user_input.len() < 100);
+    let user_input = any_bounded_string::<2>();
 
-    // Simulate various contexts where user input might appear
-    let contexts = vec![
-        format!("echo {}", escape_shell_string(&user_input)),
-        format!("VAR={}", escape_shell_value(&user_input)),
-        format!(
-            "if [ \"${{VAR}}\" = {} ]; then",
-            escape_shell_string(&user_input)
-        ),
-    ];
+    let escaped = escape_shell_string(&user_input);
+    let context = format!("echo {escaped}");
 
-    for context in contexts {
-        // Property: No command injection possible
-        kani::assert!(!can_inject_command(&context, &user_input));
-    }
+    // Everything after `echo ` is a single quoted word, so no separator in the
+    // user's input can escape into command position.
+    assert!(!contains_unescaped_metachar(&context));
 }
 
-/// Verify array bounds are always checked
-#[kani::proof]
-#[kani::unwind(5)]
-fn verify_array_bounds_safety() {
-    let array_size: usize = kani::any();
-    kani::assume(array_size > 0 && array_size < 100);
-
-    let index: usize = kani::any();
-
-    // Simulated array access check
-    if index < array_size {
-        // Safe access
-        kani::assert!(true);
-    } else {
-        // Must generate bounds check in shell
-        let check = format!("if [ {} -lt {} ]; then", index, array_size);
-        kani::assert!(check.contains("-lt"));
-    }
-}
-
-/// Helper: Check if string contains unescaped shell metacharacters
+/// Helper: does the string contain a shell metacharacter outside quotes?
 fn contains_unescaped_metachar(s: &str) -> bool {
     let mut in_quotes = false;
     let mut escaped = false;
@@ -132,7 +126,7 @@ fn contains_unescaped_metachar(s: &str) -> bool {
     false
 }
 
-/// Helper: Unescape a shell-escaped string
+/// Helper: invert `escape_shell_string`, for the round-trip property.
 fn unescape_shell_string(s: &str) -> String {
     if s.starts_with('\'') && s.ends_with('\'') {
         let inner = &s[1..s.len() - 1];
@@ -140,34 +134,4 @@ fn unescape_shell_string(s: &str) -> String {
     } else {
         s.to_string()
     }
-}
-
-/// Helper: Check if string is valid identifier
-fn is_valid_identifier(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars().all(|c| c.is_alphanumeric() || c == '_')
-        && s.chars()
-            .next()
-            .map_or(false, |c| c.is_alphabetic() || c == '_')
-}
-
-/// Helper: Check if command injection is possible
-fn can_inject_command(shell_code: &str, user_input: &str) -> bool {
-    // Simplified check: look for unquoted user input or command separators
-    let dangerous_patterns = [";", "&&", "||", "|", "`", "$(", "\n"];
-
-    for pattern in &dangerous_patterns {
-        if shell_code.contains(pattern) && !is_properly_escaped(shell_code, pattern) {
-            return true;
-        }
-    }
-
-    false
-}
-
-/// Helper: Check if pattern is properly escaped in context
-fn is_properly_escaped(code: &str, pattern: &str) -> bool {
-    // This is a simplified check - real implementation would be more sophisticated
-    // For Kani verification, we check that dangerous patterns are within quotes
-    code.contains(&format!("'{}'", pattern)) || code.contains(&format!("\"{}\"", pattern))
 }


### PR DESCRIPTION
Closes #212. Follow-up filed as #220.

`cargo +nightly kani -p bashrs --harness <any>` failed to **build** the crate — 19 errors in bashrs's own harness files. So no harness could run, including newly added correct ones, and every contract declaring `kani_harnesses:` was undischarged. `pv validate` passing meant the contract was *well-formed*, not that its obligations held.

It stayed invisible because every kani invocation in the Makefile was suffixed `|| true`.

## Three problems, only the first a typo

1. **`kani::assert!` is not a macro Kani exports.** Kani intercepts the standard `assert!`/`assert_eq!`.
2. **`escape_shell_value`, `is_valid_rust0`, `validate_rust0_ast` do not exist** in this crate, and there's no evidence they ever did.
3. **`String`/`&str` are not `kani::Arbitrary`** — and cannot be. They're unbounded heap types; BMC needs a finite state space. Every `let s: String = kani::any();` was an `E0277`. Added `crate::kani_bounded`: fixed byte array + symbolic length + alphabet constraint.

## Two harnesses deleted, not repaired

Compiling them would have produced proofs of nothing:

- **`verify_array_bounds_safety`** — asserted `true` on one branch; on the other, that a `format!` literal contains `"-lt"`. No code under test was ever reached.
- **`verify_parser_soundness`** — called the real parser on a symbolic string, checked against the two functions that don't exist. Not tractable under BMC even if they were supplied.

Two more were near-vacuous and now call the **real** escapers: one asserted properties of a `format!` literal that hold even if the escaper is the identity function; the other checked a toy re-implementation *local to the file* against a toy oracle.

A harness that cannot fail is worse than a missing one — it consumes the verification budget and reports success.

## `verify-kani` now separates two different things

| outcome | behaviour | why |
|---|---|---|
| **build failure** | **hard fail** | This *is* the GH-212 defect. Caught by `--only-codegen` in ~106s, no solver needed. |
| **no convergence** | UNPROVEN, reported, non-fatal | "Didn't finish in budget" ≠ "property is false". Failing here would make `make verify` permanently red — which is how a gate teaches people to bypass it. |

### Verified differentially

```
fixed                → --only-codegen: 0 errors, 106s; target exits 0
E0277 reintroduced   → target exits 1: "does not compile under cfg(kani)"
```

## What this does NOT claim

**None of the three surviving harnesses converge.** Measured and reported rather than papered over: CBMC spends its time in `alloc::raw_vec` / `Layout` / `LayoutError` — Rust's **allocator** — because every harness calls an escaper returning a heap `String`. Bounds of 8, 4 and 2 characters all time out, so string *length* was never the bottleneck.

Fixing that means giving the escapers an allocation-free core (`escape_shell_string_into(&str, &mut [u8])`) for harnesses to target. That changes the public signature of functions every emitted script depends on, so it's filed as **#220** rather than riding along here.

What this PR buys is that the harnesses now **build** — the precondition for any of it, and the thing that was silently false for months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)