### PR TITLE
fix(ci): a workflow TEMPLATE was living in .github/workflows/, so GitHub ran it

### DIFF
--- a/docs/examples/github-action-workflow.yml
+++ b/docs/examples/github-action-workflow.yml
@@ -1,7 +1,17 @@
-# Example: Using bashrs GitHub Action
-# Copy this to your repo's .github/workflows/ directory
+# Example: Using the bashrs GitHub Action
 #
-# This workflow demonstrates lint, score, and property checking.
+# TEMPLATE — copy this into your own repo's .github/workflows/ directory and
+# point `files:` at your scripts. It lives under docs/examples/ ON PURPOSE:
+# anything under .github/workflows/ is EXECUTED by GitHub, and this file
+# references paths that exist in YOUR repo, not in bashrs.
+#
+# It sat in .github/workflows/ from the start and ran on every push touching
+# `**/*.sh` or `**/Makefile`, failing continuously from v6.66.0 (2026-04-08)
+# because `scripts/deploy.sh` does not exist here and `--tier production` is not
+# a valid tier. Five permanently-red checks on unrelated PRs is how a team
+# learns to ignore red.
+#
+# `bashrs gate --tier` takes 1=fast, 2=pre-commit, 3=nightly.
 # See action.yml for all available inputs.
 
 name: Shell Script Quality
@@ -67,4 +77,4 @@ jobs:
       - uses: paiml/bashrs@main
         with:
           command: gate
-          args: '--tier production'
+          args: '--tier 3'


### PR DESCRIPTION
`example-bashrs.yml` says **"Copy this to your repo's .github/workflows/ directory"** in its own header. It was already *in* `.github/workflows/`, so GitHub executed it on every push touching `**/*.sh` or `**/Makefile`.

It cannot pass here, by construction:

- **`files: scripts/deploy.sh`** — doesn't exist in this repo. It's the placeholder path the reader is meant to replace.
- **`args: '--tier production'`** — `bashrs gate --tier` is a `u8` (1=fast, 2=pre-commit, 3=nightly), so clap rejects it outright:
  ```
  error: invalid value 'production' for '--tier <TIER>': invalid digit found in string
  ```

Five jobs — *Lint Shell Scripts, Lint (SARIF), Quality Score, Property Testing, Quality Gate* — have been red on every matching push since **v6.66.0 (2026-04-08)**. Four months.

I found it because it fired on an unrelated `Makefile` edit in #221.

## Fix

Moved to `docs/examples/github-action-workflow.yml`, where it's documentation rather than a running job, and corrected the invalid tier so anyone copying it doesn't inherit the bug. The header now explains *why* it lives outside `.github/workflows/`, so it doesn't get helpfully moved back.

## Why this is worth a PR rather than a shrug

Five permanently-red checks on unrelated PRs isn't a minor annoyance — it's what teaches a team that red is normal. It's the same mechanism that got the `bashrs lint` step deleted from a downstream repo in #209: a check that can't be satisfied doesn't get fixed, it gets ignored, and then it gets removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)