### PR TITLE
fix(oracle): point the extracted test module at the crate root, and test the workspace (GH-214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,28 @@ jobs:
       # candidate for mid-range hit-rate signal between copia and aprender.
       enable_sccache: true
       use_nextest: true
+      # GH-214: without this the reusable workflow runs `--lib`, which scopes to
+      # the ROOT package (bashrs-specs) and never builds rash/, bashrs-oracle,
+      # bashrs-runtime or bashrs-wasm. bashrs-oracle's test module therefore
+      # failed to compile for months while every check stayed green. `--workspace
+      # --lib` is what makes a rotting workspace member loud.
+      #
+      # Verified locally before enabling, because turning this on blind would red
+      # the whole pipeline: `cargo test --workspace --lib --no-run` builds all 5
+      # members with 0 errors (bashrs, bashrs_oracle, bashrs_runtime,
+      # bashrs_specs, bashrs_wasm).
+      test_workspace: true
+      # rash/src/testing/shellcheck_validation_tests.rs shells out to shellcheck
+      # and `.expect()`s it, so those 23 tests PANIC where it is absent. They
+      # never ran before because `--lib` scoped to the root stub package; turning
+      # test_workspace on is what surfaced them.
+      #
+      # Installed rather than skipped: that module asserts a stated critical
+      # invariant — "every generated script must pass `shellcheck -s sh`" — so
+      # skipping it in CI would swap a red for a silent green, which is the exact
+      # failure mode this repo keeps getting bitten by. infra's clean-room gate
+      # already installs shellcheck for bashrs for the same reason.
+      extra_pkgs: shellcheck
     secrets: inherit
 
   # Top-level gate: org ruleset requires status check named "gate" (exact match).

--- a/bashrs-oracle/src/lib_tests_oracle_creat.rs
+++ b/bashrs-oracle/src/lib_tests_oracle_creat.rs
@@ -1,7 +1,13 @@
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
-    use super::*;
+    // `crate::*`, not `super::*`: this file is pulled in by lib_cont.rs via
+    // `#[path = "lib_tests_oracle_creat.rs"] mod tests_extracted;`, so `super`
+    // is lib_cont — not the crate root where Oracle/ErrorCategory/Corpus/
+    // OracleConfig/ErrorFeatures/DriftStatus actually live. PMAT-229 renamed
+    // the file into that submodule and `super::*` quietly stopped reaching
+    // them; nothing built this member, so it stayed broken. See GH-214.
+    use crate::*;
 
     #[test]
     fn test_oracle_creation() {


### PR DESCRIPTION
Closes #214. (Supersedes #218, which conflicted after #219/#221/#222 landed — same two files, rebuilt cleanly on main.)

`bashrs-oracle`'s test module has not compiled since **PMAT-229** (`b2debf1710`).

`lib_cont.rs` pulls it in with `#[path = "lib_tests_oracle_creat.rs"] mod tests_extracted;`, so inside it `super` is **`lib_cont`** — not the crate root where the types live. That refactor renamed the file into the submodule and `use super::*` quietly stopped reaching them. **Six** types, not the two the issue recorded.

| | |
|---|---|
| RED on `origin/main` | `cargo test -p bashrs-oracle --lib --no-run` → **19 × E0433** |
| GREEN with this fix | **48 passed, 0 failed** |

Including the 6 `tests_extracted::*` tests never compiled, let alone run, since February.

## Why it survived months of green

Nothing in the pipeline built this member:

- CI's reusable `sovereign-ci` defaults to `--lib`, scoping to the **root** package (`bashrs-specs`) — never `rash/` or the other three members
- infra's clean-room gate ran `cargo test --lib` at the **workspace root** — the same blind spot (paiml/infra#170)

So this also sets `test_workspace: true` (`--workspace --lib`). **Verified locally before enabling**, because flipping it on an assumption would red the whole pipeline rather than fix anything: `cargo test --workspace --lib --no-run` builds all 5 members, 0 errors.

## What that immediately caught

23 further failures in `rash/src/testing/shellcheck_validation_tests.rs`. They shell out to `shellcheck` and `.expect()` it, so they **panic** where it's absent — and the CI container lacks it. They had never run.

shellcheck is **installed** (via the workflow's `extra_pkgs`) rather than the tests made to skip. That module states its own critical invariant — *"every generated script must pass `shellcheck -s sh`"* — so skipping would trade a red for a **silent green**. CI shouldn't be weaker than the release gate, which already installs it.

And I confirmed they genuinely execute rather than the install failing open (that apt step ends in `|| true`): `testing::shellcheck_validation_tests` report real per-test timings, and the suite is now **14,655 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)