### PR TITLE
chore(release): 6.66.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.66.3] - 2026-08-12
+
+### Fixed
+
+- **Five lint false positives that were driving users to disable `bashrs lint`**
+  ([#219](https://github.com/paiml/bashrs/pull/219), GH-217, GH-209). Diagnostics
+  inside quoted heredocs (`<<'EOF'`) are no longer emitted at all — the body of a
+  quoted heredoc is literal text, not shell, so SC1007 and friends had no business
+  firing there. MAKE003 now skips Make's `$$` escape before checking quoting;
+  MAKE010 recognises `|| exit`, `|| return` and `|| die`-style tails as error
+  handling; and MAKE016 is retired outright, because its autofix **corrupted
+  Makefiles**.
+- **CLI stack overflow from an oversized clap frame**
+  ([#216](https://github.com/paiml/bashrs/pull/216), [#215](https://github.com/paiml/bashrs/issues/215)).
+  Subcommand enums are split so the generated `clap` builder no longer places one
+  huge frame on the stack. This bit `cargo test` (2 MB thread stacks) while
+  `cargo nextest` (8 MB process stacks) hid it.
+- **RUSTSEC-2026-0204**: crossbeam-epoch bumped to 0.9.20
+  ([#210](https://github.com/paiml/bashrs/pull/210)).
+
+### Internal
+
+- Kani harnesses now **compile** under `cfg(kani)`, and `make verify-kani` no
+  longer swallows the failure with `|| true`
+  ([#221](https://github.com/paiml/bashrs/pull/221), [#212](https://github.com/paiml/bashrs/issues/212)).
+  The crate had not built under `cfg(kani)` since the harnesses were added. Two
+  harnesses that could not fail were deleted rather than repaired. Note the
+  harnesses do not yet converge — tracked in
+  [#220](https://github.com/paiml/bashrs/issues/220).
+- `bashrs-oracle`'s extracted test module points at the crate root instead of
+  `super`, so the member compiles again
+  ([#223](https://github.com/paiml/bashrs/pull/223), [#214](https://github.com/paiml/bashrs/issues/214)).
+  CI now runs `--workspace --lib`, which is what makes a rotting workspace member
+  loud; it had been silently broken for months because the default `--lib` scoped
+  to the root package only.
+- A workflow **template** living in `.github/workflows/` was being executed by
+  GitHub as a real workflow ([#222](https://github.com/paiml/bashrs/pull/222)).
+
 ## [6.66.2] - 2026-08-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "6.66.2"
+version = "6.66.3"
 dependencies = [
  "anyhow",
  "aprender 0.27.5",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "6.66.2"
+version = "6.66.3"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -653,14 +653,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "6.66.2"
+version = "6.66.3"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "6.66.2"
+version = "6.66.3"
 dependencies = [
  "bashrs",
  "criterion",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "6.66.2"
+version = "6.66.3"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ regex-automata = "0.5"
 regex-syntax = "0.9"
 
 [workspace.package]
-version = "6.66.2"
+version = "6.66.3"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Pragmatic AI Labs"]


### PR DESCRIPTION
Ships the user-facing fixes accumulated since 6.66.2. **None of them reach anyone until this is published** — crates.io is still on 6.66.2.

## Fixed

- **Five lint false positives that were driving users to disable `bashrs lint`** ([#219](https://github.com/paiml/bashrs/pull/219), GH-217, GH-209). Diagnostics inside quoted heredocs (`<<'EOF'`) are no longer emitted at all — a quoted heredoc body is literal text, not shell, so SC1007 and friends had no business firing there. MAKE003 now skips Make's `$$` escape before checking quoting; MAKE010 recognises `|| exit` / `|| return` / `|| die` tails as error handling; MAKE016 is **retired outright**, because its autofix corrupted Makefiles.
- **CLI stack overflow from an oversized clap frame** ([#216](https://github.com/paiml/bashrs/pull/216), [#215](https://github.com/paiml/bashrs/issues/215)). `cargo test` (2 MB thread stacks) hit it; `cargo nextest` (8 MB process stacks) hid it.
- **RUSTSEC-2026-0204** — crossbeam-epoch 0.9.20 ([#210](https://github.com/paiml/bashrs/pull/210)).

## Internal

- Kani harnesses **compile** under `cfg(kani)` again and `make verify-kani` no longer swallows failures with `|| true` ([#221](https://github.com/paiml/bashrs/pull/221)). The crate hadn't built under `cfg(kani)` since the harnesses were added. Two harnesses that *could not fail* were deleted rather than repaired. They still don't converge — [#220](https://github.com/paiml/bashrs/issues/220).
- `bashrs-oracle`'s extracted test module compiles again, and CI runs `--workspace --lib` so a rotting member is loud ([#223](https://github.com/paiml/bashrs/pull/223)).
- A workflow **template** in `.github/workflows/` was being executed as a real workflow ([#222](https://github.com/paiml/bashrs/pull/222)).

## Release hygiene

`Cargo.lock` is regenerated **in this same commit** (all 5 workspace members → 6.66.3, zero `6.66.2` left). forjar's 1.12.4 release tripped its own `lockfile-preflight` by bumping `Cargo.toml` alone; not repeating that.

Publish is gated on the mandatory infra clean-room run, and will be tagged `v6.66.3` — this repo has been publishing without git anchors, which is what made "what is unreleased?" undiagnosable here in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)