### PR TITLE
feat(linter): BASHRS001 — a suppression that does nothing now says so (#240)

### DIFF
--- a/rash/src/linter/rules/mod_lint_2.rs
+++ b/rash/src/linter/rules/mod_lint_2.rs
@@ -413,6 +413,15 @@ fn lint_shell_filtered(
         .diagnostics
         .retain(|diag| !suppression_manager.is_suppressed(&diag.code, diag.span.start_line));
 
+    // Issue #240: a comment meant as a suppression that matches none of the
+    // supported forms is silently inert. Reported AFTER filtering and at
+    // Warning, so it can itself be suppressed and can never gate a build.
+    crate::linter::suppression::report_unrecognised_directives(
+        source,
+        &suppression_manager,
+        &mut result,
+    );
+
     result
 }
 

--- a/rash/src/linter/rules/mod_lint_extended.rs
+++ b/rash/src/linter/rules/mod_lint_extended.rs
@@ -87,6 +87,13 @@ fn apply_extended_lint_rules(source: &str, result: &mut LintResult) {
         .diagnostics
         .retain(|diag| !suppression_manager.is_suppressed(&diag.code, diag.span.start_line));
 
+    // Issue #240 — this is the path `lint_shell` (and therefore the CLI) takes.
+    crate::linter::suppression::report_unrecognised_directives(
+        source,
+        &suppression_manager,
+        result,
+    );
+
     // Filter out diagnostics inside embedded programs (awk, sed, perl, etc.)
     // See: https://github.com/paiml/bashrs/issues/137
     // Security (SEC*) and determinism (DET*) rules are exempt — they detect

--- a/rash/src/linter/suppression.rs
+++ b/rash/src/linter/suppression.rs
@@ -330,3 +330,157 @@ fn is_valid_rule_code(code: &str) -> bool {
 #[cfg(test)]
 #[path = "suppression_tests_parse_file.rs"]
 mod tests_extracted;
+
+/// A comment that looks like a bashrs suppression directive but is not one.
+///
+/// Issue #240: `parse_suppression` matches four exact prefixes. Anything else —
+/// `# bashrs-disable: SC2086`, `# bashrs: disable=SC2086`, `# bashrs disable
+/// SC2086` with a space instead of `=` — is silently ignored. The author sees a
+/// directive in the source, the finding stays, and nothing anywhere says the two
+/// facts are related. That is worse than rejecting it: a suppression that does
+/// nothing looks exactly like a rule that fires anyway.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnrecognisedDirective {
+    /// 1-indexed line the comment appears on.
+    pub line: usize,
+    /// The comment text, trimmed.
+    pub text: String,
+}
+
+/// The four forms that actually work.
+pub const SUPPORTED_DIRECTIVES: &[&str] = &[
+    "# bashrs disable-file=RULE[,RULE...]",
+    "# bashrs disable-next-line=RULE",
+    "# bashrs disable-line=RULE",
+    "# bashrs disable=RULE",
+];
+
+/// Does this comment mention bashrs and disabling, without being a valid directive?
+///
+/// Deliberately narrow: it must contain BOTH "bashrs" and "disable"/"ignore" in a
+/// comment. A line merely mentioning bashrs (`# built by bashrs`) is not an
+/// attempted directive and must not be reported.
+fn looks_like_attempted_directive(line: &str) -> bool {
+    let Some(hash) = line.find('#') else {
+        return false;
+    };
+    let comment = line[hash..].to_lowercase();
+    if !comment.contains("bashrs") {
+        return false;
+    }
+    if !(comment.contains("disable") || comment.contains("ignore")) {
+        return false;
+    }
+    // A recognised directive parses; anything else in this shape does not.
+    parse_suppression(line, 1).is_none()
+}
+
+/// Find comments that were probably meant as suppressions but are inert.
+///
+/// Returned rather than reported here, so the caller decides the severity and
+/// this module keeps no dependency on `Diagnostic`.
+pub fn unrecognised_directives(source: &str) -> Vec<UnrecognisedDirective> {
+    source
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| looks_like_attempted_directive(l))
+        .map(|(i, l)| UnrecognisedDirective {
+            line: i + 1,
+            text: l.trim().to_string(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod unrecognised_tests {
+    use super::*;
+
+    /// The reported case (#240) and its near neighbours: each LOOKS like a
+    /// directive, and each does nothing.
+    #[test]
+    fn near_miss_directives_are_reported() {
+        for line in [
+            "# bashrs-disable: SC2086",
+            "# bashrs: disable=SC2086",
+            "# bashrs disable SC2086",
+            "# bashrs ignore SC2086",
+            "echo hi  # bashrs-disable-line: SC2086",
+        ] {
+            let found = unrecognised_directives(line);
+            assert_eq!(found.len(), 1, "not reported: {line}");
+            assert_eq!(found[0].line, 1);
+        }
+    }
+
+    /// Guard the guard: every SUPPORTED form must stay silent, or the warning
+    /// fires on correct code and becomes noise people learn to ignore.
+    #[test]
+    fn supported_directives_are_not_reported() {
+        for line in [
+            "# bashrs disable-file=SC2086,DET002",
+            "# bashrs disable-next-line=SC2086",
+            "echo $var  # bashrs disable-line=SC2086",
+            "# bashrs disable=SEC010",
+        ] {
+            assert!(
+                unrecognised_directives(line).is_empty(),
+                "a SUPPORTED directive was reported as unrecognised: {line}"
+            );
+        }
+    }
+
+    /// A comment that merely mentions bashrs is not an attempted directive.
+    #[test]
+    fn ordinary_comments_are_not_reported() {
+        for line in [
+            "# built by bashrs",
+            "# see bashrs docs for details",
+            "# disable the cache here",
+            "echo 'bashrs disable=SC2086'",
+            "#!/usr/bin/env bash",
+        ] {
+            assert!(
+                unrecognised_directives(line).is_empty(),
+                "ordinary comment reported: {line}"
+            );
+        }
+    }
+
+    /// shellcheck's own directive is understood elsewhere and must not be
+    /// reported here.
+    #[test]
+    fn shellcheck_directives_are_not_reported() {
+        assert!(unrecognised_directives("# shellcheck disable=SC2086").is_empty());
+    }
+}
+
+/// Append a `BASHRS001` warning for every comment that was meant as a
+/// suppression but matches none of the supported forms.
+///
+/// Lives here, and is called from BOTH lint entry points, because the two have
+/// already diverged once: `lint_shell` (mod_lint.rs) and `lint_shell_with_path`
+/// (mod_lint_2.rs) each apply suppressions separately, so wiring only one meant
+/// the CLI — which uses `lint_shell` — reported nothing while the unit tests
+/// passed. Same shape as the quoting allowlist that did nothing on one of its
+/// two paths (paiml/bashrs#247).
+pub fn report_unrecognised_directives(
+    source: &str,
+    manager: &SuppressionManager,
+    result: &mut crate::linter::LintResult,
+) {
+    for d in unrecognised_directives(source) {
+        if manager.is_suppressed("BASHRS001", d.line) {
+            continue;
+        }
+        result.add(crate::linter::Diagnostic::new(
+            "BASHRS001",
+            crate::linter::Severity::Warning,
+            format!(
+                "`{}` is not a recognised bashrs directive and does nothing. Supported: {}",
+                d.text,
+                SUPPORTED_DIRECTIVES.join(", ")
+            ),
+            crate::linter::Span::new(d.line, 1, d.line, d.text.len() + 1),
+        ));
+    }
+}


### PR DESCRIPTION
Closes #240.

`parse_suppression` matches four exact prefixes. Anything else is silently ignored:

```sh
# bashrs-disable: SC2086     # does nothing
# bashrs: disable=SC2086     # does nothing
# bashrs disable SC2086      # does nothing (space, not `=`)
```

The author sees a directive in the source and the finding still in the output, with **nothing connecting the two**. That is worse than rejecting the comment outright: a suppression that does nothing looks exactly like a rule that fires anyway, so the natural next step is to distrust the linter.

## The rule

A comment that mentions `bashrs` **and** `disable`/`ignore`, and does not parse as a supported form, is reported as `BASHRS001` with the four working forms listed in the message:

```
BASHRS001: `# bashrs-disable: SC2086` is not a recognised bashrs directive and
does nothing. Supported: # bashrs disable-file=RULE[,RULE...],
# bashrs disable-next-line=RULE, # bashrs disable-line=RULE, # bashrs disable=RULE
```

`Severity::Warning`, deliberately — it must never gate a build, and it can itself be suppressed once read.

Detection is narrow, and three tests pin that: `# built by bashrs` and `# disable the cache here` are not attempted directives, every **supported** form stays silent, and shellcheck's own `# shellcheck disable=` is understood elsewhere. A warning that fires on correct code is noise people learn to ignore — which is the failure this rule exists to prevent.

## A divergence worth naming

The first cut wired the emission into `lint_shell_with_path` only. **Unit tests passed and the CLI printed nothing**, because the CLI uses `lint_shell` — the two entry points apply suppressions in separate places.

That is the same shape as the quoting allowlist in #247, which silently did nothing on one of its two paths. The emission now lives in `suppression.rs` and is called from both, with the reason written down where the next person will read it.

## Verification

End-to-end through the built binary, not just in tests:

```
near-miss `# bashrs-disable: SC2086`  -> BASHRS001 reported
supported `# bashrs disable-line=...` -> 0
rag / rag-reindex.sh / nas-sweep.sh   -> 0 each
```

15,016 tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLii4JZqyTauqbQWwUg7uf