### PR TITLE
fix(lint): SC1044 read `<<<'x'` as an unterminated heredoc

### DIFF
--- a/rash/src/linter/rules/sc1044.rs
+++ b/rash/src/linter/rules/sc1044.rs
@@ -21,6 +21,27 @@
 //! Every heredoc must be terminated by its delimiter on its own line.
 //! If the closing delimiter is never found, the shell will consume the rest
 //! of the script as heredoc content, causing confusing errors.
+//!
+//! # `<<<` is a herestring, not a heredoc
+//!
+//! ```bash
+//! grep -c . <<<'hello'      # one line of input. No body, no terminator.
+//! ```
+//!
+//! The delimiter regex is unanchored, so on `<<<'hello'` it matched the `<<`
+//! at offset 1 — the *second and third* angle brackets — read `'hello'` as a
+//! quoted terminator, and reported an unterminated heredoc for a construct
+//! that has no body to terminate. A gating ERROR, on correct shell.
+//!
+//! Only the quoted spellings were affected, because `<<<$var` and `<<<word`
+//! leave a non-word character (`$`) or make the third `<` part of a match that
+//! still starts at offset 0. That is why this survived: the two forms a script
+//! is most likely to contain are the two that behaved.
+//!
+//! SC1078's scanner already models this correctly — it classifies a `<<` into
+//! `Heredoc` / `Herestring` / `Neither` — so the rule here is the outlier, and
+//! the fix is the same distinction: a `<<` preceded by another `<` is the tail
+//! of a herestring and starts nothing.
 
 use crate::linter::{Diagnostic, LintResult, Severity, Span};
 use regex::Regex;
@@ -39,6 +60,54 @@ fn extract_delimiter<'a>(caps: &'a regex::Captures<'a>) -> Option<&'a str> {
         .map(|m| m.as_str())
 }
 
+/// Where a heredoc opens on a line, and the word that must close it.
+struct HeredocOpen {
+    /// Byte offset of the `<<` within the line.
+    start: usize,
+    /// Byte length of the whole `<<DELIM` match, for the span.
+    len: usize,
+    delimiter: String,
+    /// `<<-` strips leading tabs from the terminator line too.
+    strips_tabs: bool,
+}
+
+/// The first `<<` on the line that actually opens a heredoc.
+///
+/// The regex has no lookbehind, so a match that begins immediately after
+/// another `<` is the tail of a `<<<` herestring and is skipped. Scanning ON
+/// rather than returning `None` at the first herestring keeps a real heredoc
+/// later on the same line visible: `grep . <<<"$x" && cat <<EOF` opens one.
+fn first_heredoc_start(line: &str) -> Option<HeredocOpen> {
+    HEREDOC_START.captures_iter(line).find_map(|caps| {
+        let m = caps.get(0)?;
+        // Group 0 begins at the `<<`; a `<` right before it means `<<<`.
+        if m.start()
+            .checked_sub(1)
+            .is_some_and(|prev| line.as_bytes()[prev] == b'<')
+        {
+            return None;
+        }
+        Some(HeredocOpen {
+            start: m.start(),
+            len: m.len(),
+            delimiter: extract_delimiter(&caps)?.to_string(),
+            strips_tabs: line[m.start()..].starts_with("<<-"),
+        })
+    })
+}
+
+/// Index of the line that closes `open`, searching from `from` onwards.
+fn terminator_line(lines: &[&str], from: usize, open: &HeredocOpen) -> Option<usize> {
+    lines.iter().enumerate().skip(from).find_map(|(j, line)| {
+        let candidate = if open.strips_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line
+        };
+        (candidate.trim() == open.delimiter).then_some(j)
+    })
+}
+
 /// Check for unterminated heredocs
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
@@ -47,52 +116,32 @@ pub fn check(source: &str) -> LintResult {
 
     while i < lines.len() {
         let line = lines[i];
-        let trimmed = line.trim_start();
-        if trimmed.starts_with('#') {
+        if line.trim_start().starts_with('#') {
             i += 1;
             continue;
         }
 
-        if let Some(caps) = HEREDOC_START.captures(line) {
-            if let Some(delimiter) = extract_delimiter(&caps) {
-                let full_match = caps.get(0).unwrap();
-                let is_strip = line[full_match.start()..].starts_with("<<-");
+        let Some(open) = first_heredoc_start(line) else {
+            i += 1;
+            continue;
+        };
 
-                // Search for the closing delimiter
-                let mut found = false;
-                let mut j = i + 1;
-                while j < lines.len() {
-                    let candidate = if is_strip {
-                        lines[j].trim_start_matches('\t')
-                    } else {
-                        lines[j]
-                    };
-                    if candidate.trim() == delimiter {
-                        found = true;
-                        i = j + 1;
-                        break;
-                    }
-                    j += 1;
-                }
-
-                if !found {
-                    let line_num = i + 1;
-                    let col = full_match.start() + 1;
-                    let span = Span::new(line_num, col, line_num, col + full_match.len());
-                    let diag = Diagnostic::new(
-                        "SC1044",
-                        Severity::Error,
-                        format!("Couldn't find end token '{delimiter}' for this heredoc"),
-                        span,
-                    );
-                    result.add(diag);
-                    i += 1;
-                }
-            } else {
+        match terminator_line(&lines, i + 1, &open) {
+            Some(j) => i = j + 1,
+            None => {
+                let line_num = i + 1;
+                let col = open.start + 1;
+                result.add(Diagnostic::new(
+                    "SC1044",
+                    Severity::Error,
+                    format!(
+                        "Couldn't find end token '{}' for this heredoc",
+                        open.delimiter
+                    ),
+                    Span::new(line_num, col, line_num, col + open.len),
+                ));
                 i += 1;
             }
-        } else {
-            i += 1;
         }
     }
 
@@ -146,6 +195,47 @@ mod tests {
     #[test]
     fn test_sc1044_no_false_positive_comment() {
         let script = "# cat <<EOF\nhello\n# not a heredoc";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 0);
+    }
+
+    /// A herestring has no body and no terminator. Every spelling of one, and
+    /// one row per QUOTING FORM rather than one for the form as a whole —
+    /// `<<<$var` and `<<<word` were always fine and would have signed off on
+    /// the bug, which is exactly how it shipped.
+    #[test]
+    fn test_sc1044_herestring_is_not_a_heredoc() {
+        for script in [
+            "grep -c . <<<'hello'",
+            "grep -c . <<<\"hello\"",
+            "grep -c . <<<\"$x\"",
+            "grep -c . <<<word",
+            "grep -qxF -- \"$j\" <<<'literal with spaces'",
+            "read -r a b <<<\"$line\"",
+        ] {
+            let result = check(script);
+            assert_eq!(
+                result.diagnostics.len(),
+                0,
+                "herestring reported as an unterminated heredoc: {script}"
+            );
+        }
+    }
+
+    /// Skipping the herestring must SCAN ON, not give up on the line: a real
+    /// heredoc opened after one is still unterminated and must still be caught.
+    #[test]
+    fn test_sc1044_real_heredoc_after_a_herestring_still_flagged() {
+        let script = "grep . <<<'x' && cat <<EOF\nbody\n# no terminator";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result.diagnostics[0].message.contains("EOF"));
+    }
+
+    /// ...and a terminated one after a herestring is still clean.
+    #[test]
+    fn test_sc1044_terminated_heredoc_after_a_herestring_is_clean() {
+        let script = "grep . <<<'x' && cat <<EOF\nbody\nEOF";
         let result = check(script);
         assert_eq!(result.diagnostics.len(), 0);
     }


### PR DESCRIPTION
A herestring has no body and nothing to terminate, but this was a gating **ERROR**:

```console
$ cat hs.sh
#!/bin/sh
grep -c . <<<'hello'

$ bashrs lint hs.sh
✗ 2:12-43 [error] SC1044: Couldn't find end token 'hello' for this heredoc
Summary: 1 error(s), 0 warning(s), 0 info(s)
```

## Why

`HEREDOC_START` is unanchored. On `<<<'hello'` it matched the `<<` at **offset 1** — the *second and third* angle brackets — and read `'hello'` as a quoted terminator. `check()` took the first match on the line unconditionally.

**Why it survived:** only the *quoted* spellings were affected.

| form | matched at | verdict before |
|---|---|---|
| `<<<'hello'` | offset 1 | ❌ false error |
| `<<<"hello"` | offset 1 | ❌ false error |
| `<<<$var` | — | ✅ (non-word `$` where a delimiter would be) |
| `<<<word` | offset 0 | ✅ (third `<` inside the match) |

The two forms a script is most likely to contain are the two that behaved, so the rule looked correct in every file anyone tried. Found while writing a guard whose self-test fixture was `package_refs <<<'run: cargo test'`.

## The fix

SC1078's scanner **already models this correctly** — it classifies each `<<` into `Heredoc` / `Herestring` / `Neither`. This rule is the outlier, using a bare regex instead. `first_heredoc_start()` now skips any match whose start is immediately preceded by `<`, and — this part matters — **scans on** rather than giving up on the line, so a real heredoc opened after a herestring is still caught:

```bash
grep . <<<'x' && cat <<EOF     # EOF unterminated -> still 1 diagnostic
```

## Discrimination — RED without the fix

Delete the four-line herestring guard: the three new tests fail, the six pre-existing ones still pass, so they test the **fix**, not the refactor.

```
test_sc1044_herestring_is_not_a_heredoc ... FAILED
  herestring reported as an unterminated heredoc: grep -c . <<<'hello'
  left: 1, right: 0
test_sc1044_real_heredoc_after_a_herestring_still_flagged ... FAILED
test_sc1044_terminated_heredoc_after_a_herestring_is_clean ... FAILED

test result: FAILED. 6 passed; 3 failed
```

**One row per quoting form, not one per form.** `<<<$var` and `<<<word` were always fine and would have signed off on the bug — a fixture per *variant* is the only thing that catches this. Same lesson paiml/infra's python census learned when a heredoc regex saw `python3 - <<PY` but not `python3 - "$f" <<PY`, and printed `unlisted 0` over four live call sites for six days.

## Complexity

The pre-commit gate refused this file — and it was right to, but it was **already** refusing it before this change. `check()` was Cyclomatic 9 / Cognitive 35 on `main`, over threshold, with a nested terminator search and a `found` flag. Extracting `HeredocOpen` + `terminator_line()` takes it to **Cyclomatic 4 / Cognitive 10**, and the file from Cognitive 35 to 15. Passed on its merits; no `--no-verify`.

## Verified on the artifact, not the claim about it

`cargo build --release`, then run the binary:

```
grep -c . <<<'hello'      ->  ✓ No issues found        (was: 1 error)
cat <<EOF / body / EOF    ->  Summary: 1 error(s)      (real heredoc, unchanged)
```

- `cargo test -p bashrs --lib linter::` — **5834 passed; 0 failed**
- `cargo fmt --check` — clean
- `cargo clippy --lib --all-features` — 0 errors

No `.pmat/baseline.json` churn (the hook stages it; dropped deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMdV9icqNz2jis3rB2PaKQ