### PR TITLE
feat(skill): adversarial-crux-pr — the gate before a lint-fix PR

### DIFF
--- a/.claude/skills/adversarial-crux-pr/SKILL.md
+++ b/.claude/skills/adversarial-crux-pr/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: adversarial-crux-pr
+description: The gate every bashrs lint-rule change passes before a PR is opened. Two halves — an ADVERSARIAL review that tries to break the fix by hunting the false negative it may have introduced, and a CRUX competitive analysis that checks the fix against how shellcheck, mvdan/sh and tree-sitter-bash solve the same problem. Invoke it when the user says "adversarial-crux", "harden this fix", "gate this PR", "crux this lint change", or before opening ANY PR that touches a lint rule, the lexer, or a diagnostic code. NOT a code formatter and NOT a general reviewer — it asks two questions and refuses to pass a fix that cannot answer them.
+---
+
+# adversarial-crux-pr — the gate before the PR
+
+Two questions, asked of a lint fix before anyone is allowed to open a pull
+request for it:
+
+> **1. What does this fix now FAIL to catch?**
+> **2. How does the field solve this, and are we diverging on purpose?**
+
+A linter earns its place by being trusted when it is red. Every fix to a false
+positive moves the rule's boundary, and a boundary can be moved too far. This
+skill exists because the cheapest way to make a noisy rule quiet is to make it
+wrong in the other direction, and nothing in a normal review catches that.
+
+```bash
+# from the bashrs checkout, on the branch carrying the fix
+bash .claude/skills/adversarial-crux-pr/gate.sh --rule SC1078 --corpus ~/src/rmedia/scripts
+bash .claude/skills/adversarial-crux-pr/gate.sh --self-test     # prove the gate can fail
+```
+
+---
+
+## The exit code says whether the GATE worked, not whether the fix is good
+
+```
+exit 0   the gate RAN and the fix survived both halves. Open the PR.
+exit 1   the fix FAILED a half. Findings below. Do not open the PR.
+exit 2   the GATE could not run. Nothing was measured. This is not a pass.
+```
+
+`exit 2` is the one people get wrong. An absent shellcheck, an unreadable
+corpus, a `cargo build` failure — none of those are a clean bill of health.
+A gate that cannot measure must never resolve to "fine".
+
+---
+
+## Half one — ADVERSARIAL: hunt the false negative
+
+**This half outranks everything else in the skill.** A false positive is noise;
+a false negative is a defect shipped under a green check. Trading the first for
+the second is a net loss even when the count goes down.
+
+### The rule: every rule you touch keeps a must-still-fire case
+
+For each rule the change affects, the PR must carry a test whose *only* job is
+to prove the rule still fires on the genuine defect it exists for. Not "the
+tests pass" — a specific case that goes red if the rule goes silent.
+
+The pairs that matter for the lexer family, and why each is easy to break while
+fixing its false positive:
+
+| rule | false positive being fixed | what it must STILL catch |
+|---|---|---|
+| `SC1078` | a `"` legally spanning newlines (`python3 -c "…"`) | a genuinely unterminated `"` running to EOF |
+| `SC1128` | a `#!` inside a heredoc writing a fixture | a real shebang on line 5 of the script itself |
+| `SC2188` | `<svg …>` inside a heredoc body | a real `> out.txt` with no command |
+| `SC1028` / `SC2104` | parens/brackets inside a quoted string | real unescaped parens inside a real `[ ]` |
+| `SC2154` | a var assigned in a `;`-separated list | a genuinely unassigned variable |
+| `SC1035` | `for` matching inside `git for-each-ref` | a real `forx` with a genuinely missing space |
+
+Teach the lexer to *know* it is inside a quote or a heredoc. Do not teach the
+rule to skip lines that look difficult.
+
+### Construct the attack, do not imagine it
+
+Write the broken shell. Run the built binary against it. Paste the output.
+"The rule should still fire" is not evidence; a red test is.
+
+### Read the diff, not the summary
+
+A fix can be a suppression in disguise. Look specifically for:
+
+- a rule disabled, or its severity lowered so the count drops
+- a file-pattern or path exclusion that happens to cover the corpus
+- an early `return` on a condition the corpus always satisfies
+- a threshold moved to exactly the current measurement
+- the corpus added to an allowlist
+
+If the honest conclusion is that a rule cannot be made accurate, **disabling it
+is a legitimate outcome** — stated explicitly, with the reason. What is not
+legitimate is a rule that still claims to check something it no longer checks.
+
+### Differential-test against the reference implementation
+
+`shellcheck` owns the `SCxxxx` namespace. For any input where bashrs and
+shellcheck now disagree on a shared code, the PR needs a written justification.
+Silent divergence on a borrowed identifier is how a code stops meaning anything.
+
+Run all three, because they disagree in informative ways:
+
+```bash
+bashrs lint "$f"          # us
+shellcheck -S error "$f"  # the reference for SCxxxx
+bash -n "$f"              # the only definition that actually runs
+```
+
+### The signal you are protecting
+
+Count the findings you must NOT lose, before and after, and print both. On the
+rmedia corpus that is `SEC011`, `SEC010` and `DET002` — the families that found
+a real `rm -rf` hazard through a symlink where a source and its destination
+resolved to one directory. If the error count falls partly because those went
+quiet, the fix has destroyed the reason to run the tool.
+
+**Print the denominator.** "0 false positives" over 0 scripts scanned is the
+oldest way to look clean.
+
+---
+
+## Half two — CRUX: how does the field solve this?
+
+Competitive analysis is not flattery in either direction. Its job is to stop
+bashrs re-deriving a solved problem badly, and to make a deliberate divergence
+legible as a decision rather than an accident.
+
+### The comparands, and what each is good for
+
+| tool | language / approach | ask it about |
+|---|---|---|
+| **shellcheck** | Haskell, parser combinators | how a heredoc body and a multi-line `"` are *represented*; it is the reference for `SCxxxx` |
+| **mvdan/sh** | Go, full bash parser with a documented AST | how a real AST models command lists, quoting, and word boundaries |
+| **tree-sitter-bash** | incremental GLR grammar | how editors get partial/broken input right without a full parse |
+| **clippy** | Rust, non-shell | lint *namespacing* and cross-tool suppression — the model for avoiding code collisions |
+
+### What the write-up must answer, per fix
+
+1. **What does the field do?** Mechanism, not marketing. "shellcheck handles it"
+   is not an answer; *how it represents the construct* is.
+2. **What does bashrs do today?**
+3. **Does this fix match the field's approach, or diverge?**
+4. **Where divergence is defensible, and where it is a mistake we should not
+   repeat.**
+
+Be honest where bashrs is genuinely better, and where a competitor carries the
+same bug. The point is a correct fix, not a favourable comparison.
+
+### Namespace collisions are a CRUX finding, not a cosmetic one
+
+When bashrs emits an `SCxxxx` code whose meaning differs from shellcheck's, three
+things break at once, and none of them are style:
+
+1. `# shellcheck disable=SCxxxx` in a shared codebase suppresses the wrong
+   diagnostic in one tool or the other.
+2. Any baseline, ratchet or dashboard keyed on code numbers silently conflates
+   two checks.
+3. A user who looks the code up reads documentation for something else.
+
+`SEC###`, `DET###` and `IDEM###` already namespace correctly. That is the model.
+
+**Renaming a code is a breaking change**, and its cost grows every day it ships:
+each new baseline written against the wrong meaning is another thing that breaks
+at reconciliation. When this half finds a collision, say so with the deadline
+shape attached — volume argues for fixing noisy rules first, irreversibility
+argues for fixing the namespace first, and irreversibility wins.
+
+Migration is part of the fix, not a follow-up: accept the old code as a
+deprecated alias in suppression pragmas, so an existing baseline does not
+*silently* stop suppressing on upgrade.
+
+---
+
+## Running it as a gate
+
+This runs **before** the PR is opened, not as a review comment afterwards. A
+gate that runs after the PR is a gate that gets argued with.
+
+```
+1. reproduce      the reported false positive, from the named file and line
+2. fix            the cause, not the symptom
+3. ADVERSARIAL    construct the false negative; prove the rule still fires
+4. differential   bashrs vs shellcheck vs bash -n
+5. CRUX           how the field solves it; where we diverge and why
+6. denominators   corpus count before/after, and the SEC/DET counts unchanged
+7. THEN open the PR, with 3-6 in the body
+```
+
+A PR body that does not contain the must-still-fire evidence and the CRUX
+comparison has not passed this gate, whatever the CI says.
+
+---
+
+## Why this exists
+
+Measured on a 45-script production corpus at bashrs 6.67.0:
+
+```
+bashrs lint            150 error-severity findings
+shellcheck -S error      0
+bash -n                  0
+```
+
+All 150 were false positives, clustered into six lexer and namespace defects.
+The cost was not the noise. The cost was that `SEC011` had found a real
+destructive-`rm` hazard in that same corpus, and a consumer running the tool as
+a gate had to treat every red as *"look, don't obey"* — which is the state in
+which a gate stops being a gate.
+
+This skill is the thing that keeps the next fix from buying quiet with blindness.

--- a/.claude/skills/adversarial-crux-pr/fixtures/bare-redirect.sh
+++ b/.claude/skills/adversarial-crux-pr/fixtures/bare-redirect.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# GENUINELY BROKEN: a redirection with no command in front of it.
+# SC2188 must fire here.
+set -euo pipefail
+> out.txt

--- a/.claude/skills/adversarial-crux-pr/fixtures/late-shebang.sh
+++ b/.claude/skills/adversarial-crux-pr/fixtures/late-shebang.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# GENUINELY BROKEN: a second, real shebang below line 1 — not inside any
+# heredoc. SC1128 must fire here.
+set -euo pipefail
+echo hello
+#!/bin/sh

--- a/.claude/skills/adversarial-crux-pr/fixtures/t4-live-specimen.sh
+++ b/.claude/skills/adversarial-crux-pr/fixtures/t4-live-specimen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# T4 LIVE SPECIMEN — bashrs 6.67.0 reports SC1078 on the line below and is
+# WRONG: the string is closed. shellcheck and `bash -n` both accept it.
+#
+# This fixture must go CLEAN when T4 lands. If SC1078 reappears here, T4 has
+# regressed. It is deliberately the only place this construct lives, so the
+# gate itself can stay lint-clean while the specimen is still measurable.
+set -euo pipefail
+printf %s "not this PR%s problem" "'s"

--- a/.claude/skills/adversarial-crux-pr/fixtures/unassigned-var.sh
+++ b/.claude/skills/adversarial-crux-pr/fixtures/unassigned-var.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# GENUINELY BROKEN: never_set_anywhere is referenced and never assigned.
+# SC2154 must fire here.
+set -euo pipefail
+echo "$never_set_anywhere"

--- a/.claude/skills/adversarial-crux-pr/fixtures/unterminated-quote.sh
+++ b/.claude/skills/adversarial-crux-pr/fixtures/unterminated-quote.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# GENUINELY BROKEN: this quote is never closed and runs to EOF.
+# SC1078 must fire here. If a lexer fix quiets it, that fix bought silence
+# with blindness.
+echo "this string never closes

--- a/.claude/skills/adversarial-crux-pr/gate.sh
+++ b/.claude/skills/adversarial-crux-pr/gate.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# adversarial-crux-pr — the gate a bashrs lint fix passes before its PR exists.
+#
+# Two halves, and the first one outranks everything else here:
+#
+#   ADVERSARIAL  does the fix still catch the defect the rule exists for?
+#   CRUX         does the fix match how the field solves it, or diverge on purpose?
+#
+# A false positive is noise. A false negative is a defect shipped under a green
+# check. Trading the first for the second is a net loss even when the count
+# falls, and nothing in an ordinary review catches it — the diff looks like an
+# improvement and the test suite goes green.
+#
+# EXIT CODES, and the third is the one people get wrong:
+#
+#   0  the gate RAN and the fix survived. Open the PR.
+#   1  the fix FAILED a half. Do not open the PR.
+#   2  the GATE could not run. NOTHING was measured. This is not a pass.
+#
+# An absent shellcheck, an unreadable corpus or a failed build are all exit 2.
+# A gate that cannot measure must never resolve to "fine" — this fleet has been
+# bitten repeatedly by a checker that reported a result it had not measured.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$HERE/fixtures"
+
+RULE=""
+CORPUS=""
+SELFTEST=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --rule)      RULE="${2:-}"; shift 2 ;;
+        --corpus)    CORPUS="${2:-}"; shift 2 ;;
+        --self-test) SELFTEST=1; shift ;;
+        -h|--help)
+            printf 'usage: gate.sh [--rule CODE] [--corpus DIR] [--self-test]\n'
+            exit 0 ;;
+        *) printf 'gate: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+# ── The instrument must be present before it may report anything ─────────────
+#
+# Each of these is a NO-GO rather than a skip. "shellcheck was not installed so
+# we did not differential-test" is exactly the shape that lets a divergence
+# ship: the check is absent, the output is green, and nobody can tell those
+# apart afterwards.
+need() {
+    command -v "$1" >/dev/null 2>&1 && return 0
+    printf '  NO-GO: %s is not installed, so %s\n' "$1" "$2"
+    printf '  This is not a pass.\n'
+    exit 2
+}
+need bashrs     "the fix under test cannot be exercised."
+need shellcheck "the SCxxxx namespace has no reference to differ against."
+need bash       "nothing can confirm the corpus is valid shell."
+
+printf '== adversarial-crux-pr ==\n'
+printf '   bashrs     %s\n' "$(bashrs --version 2>/dev/null | head -1)"
+printf '   shellcheck %s\n' "$(shellcheck --version 2>/dev/null | awk '/version:/{print $2}')"
+
+# ── HALF ONE: the must-still-fire corpus ─────────────────────────────────────
+#
+# Every fixture here is GENUINELY BROKEN shell. Each names the rule that must
+# flag it. If a fix quiets one of these, it has bought silence with blindness
+# and the gate refuses the PR.
+#
+# These are deliberately NOT the false-positive cases. A fix is judged on what
+# it still catches, not on what it stopped complaining about.
+fired=0
+missed=0
+checked=0
+
+must_fire() {
+    _mf_file="$1"
+    _mf_rule="$2"
+    _mf_why="$3"
+    checked=$((checked + 1))
+    if [ ! -f "$_mf_file" ]; then
+        printf '  NO-GO: fixture missing: %s\n' "$_mf_file"
+        printf '  The gate cannot judge a fix against a corpus it does not have.\n'
+        exit 2
+    fi
+    # NOT `bashrs ... | grep -q`: grep -q closes the pipe on its first match,
+    # SIGPIPEs bashrs, and under `set -o pipefail` the pipeline returns THAT —
+    # so a PASSING check reads as a failure. Capture first, then match.
+    _mf_out=$(bashrs lint "$_mf_file" 2>/dev/null)
+    if printf '%s' "$_mf_out" | grep -q "$_mf_rule"; then
+        printf '  ok    %-8s still fires — %s\n' "$_mf_rule" "$_mf_why"
+        fired=$((fired + 1))
+    else
+        printf '  LOST  %-8s NO LONGER FIRES on %s\n' "$_mf_rule" "$_mf_file"
+        printf '        %s\n' "$_mf_why"
+        printf '        A false positive was traded for a FALSE NEGATIVE.\n'
+        missed=$((missed + 1))
+    fi
+}
+
+printf '\n-- half one: ADVERSARIAL — what does the fix no longer catch? --\n'
+
+must_fire "$FIXTURES/unterminated-quote.sh"  SC1078 "a quote that genuinely runs to EOF"
+must_fire "$FIXTURES/late-shebang.sh"        SC1128 "a real shebang that is genuinely not on line 1"
+must_fire "$FIXTURES/bare-redirect.sh"       SC2188 "a real redirection with no command"
+must_fire "$FIXTURES/unassigned-var.sh"      SC2154 "a variable genuinely never assigned"
+
+printf '\nmust-still-fire: %s checked, %s fired, %s LOST\n' "$checked" "$fired" "$missed"
+
+if [ "$checked" -eq 0 ]; then
+    printf 'NO-GO: no fixture was exercised. A gate that inspected nothing is not a pass.\n'
+    exit 2
+fi
+
+# ── The self-test proves the gate itself can fail ────────────────────────────
+#
+# A green never shown capable of red is not evidence. --self-test asserts the
+# instrument fires on a fixture built to trip it; if that comes back clean, the
+# gate is broken and must not be used to clear a PR.
+if [ "$SELFTEST" -eq 1 ]; then
+    printf '\n-- self-test: the gate must be able to FAIL --\n'
+    # Same SIGPIPE trap as above: capture, then match.
+    _st_out=$(bashrs lint "$FIXTURES/unterminated-quote.sh" 2>/dev/null)
+    if printf '%s' "$_st_out" | grep -q SC1078; then
+        printf '  ok    the instrument fires on a known-broken fixture\n'
+    else
+        printf '  NO-GO: the instrument did not fire on a fixture built to trip it.\n'
+        printf '  Refusing to clear any PR with a checker that cannot go red.\n'
+        exit 2
+    fi
+fi
+
+# ── HALF TWO: the differential, over a real corpus ───────────────────────────
+#
+# The SCxxxx namespace is owned by shellcheck, and `bash -n` is the only
+# definition that actually runs. Where bashrs reports an error both of them
+# accept, that is a false-positive CANDIDATE — not proof, but the place to look.
+#
+# (This paragraph is deliberately NOT written as "# shellcheck owns …": a
+# comment beginning `# shellcheck ` is parsed as a DIRECTIVE, and shellcheck
+# rejected the prose with SC1073 "Couldn't parse this shellcheck directive".
+# Found by dogfooding this gate against shellcheck.)
+fp_candidates=0
+scanned=0
+sec_kept=0
+
+if [ -n "$CORPUS" ]; then
+    printf '\n-- half two: DIFFERENTIAL over %s --\n' "$CORPUS"
+    if [ ! -d "$CORPUS" ]; then
+        printf '  NO-GO: corpus is not a directory: %s\n' "$CORPUS"
+        exit 2
+    fi
+    for f in "$CORPUS"/*.sh; do
+        [ -e "$f" ] || continue
+        scanned=$((scanned + 1))
+        b=$(bashrs lint "$f" 2>/dev/null | grep -c '\[error\]')
+        s=$(shellcheck -S error "$f" 2>/dev/null | grep -c '^' )
+        bash -n "$f" 2>/dev/null; n=$?
+        # SEC/DET are the families that justify running the tool at all. Count
+        # them separately so a falling error total can never hide them going out.
+        k=$(bashrs lint "$f" 2>/dev/null | grep -cE '(SEC|DET|IDEM)[0-9]+')
+        sec_kept=$((sec_kept + k))
+        if [ "${b:-0}" -gt 0 ] && [ "${s:-0}" -eq 0 ] && [ "$n" -eq 0 ]; then
+            fp_candidates=$((fp_candidates + b))
+        fi
+    done
+    # THE DENOMINATOR. "0 false positives" over 0 scripts is the oldest way to
+    # look clean, and this fleet's most-repeated defect.
+    printf '\ndifferential: %s script(s) scanned\n' "$scanned"
+    printf '              %s bashrs error(s) that BOTH shellcheck and bash -n accept\n' "$fp_candidates"
+    printf '              %s SEC/DET/IDEM finding(s) still reported\n' "$sec_kept"
+    if [ "$scanned" -eq 0 ]; then
+        printf 'NO-GO: no script was scanned — is the corpus path right?\n'
+        exit 2
+    fi
+    if [ "$sec_kept" -eq 0 ]; then
+        printf '\nNO-GO: not one SEC/DET/IDEM finding in the whole corpus.\n'
+        printf 'Those families are the reason to run this tool. Either the corpus is\n'
+        printf 'wrong or a fix has silenced them; the gate will not guess which.\n'
+        exit 2
+    fi
+fi
+
+# ── Verdict ──────────────────────────────────────────────────────────────────
+printf '\n'
+if [ "$missed" -gt 0 ]; then
+    printf 'FAIL: %s rule(s) stopped firing on a genuine defect.\n' "$missed"
+    printf 'A quieter linter that misses real bugs is worse than a noisy one.\n'
+    printf 'Do not open the PR.\n'
+    exit 1
+fi
+
+printf 'OK: every touched rule still fires on the defect it exists for.\n'
+if [ -n "$CORPUS" ] && [ "$fp_candidates" -gt 0 ]; then
+    printf 'NOTE: %s false-positive candidate(s) remain in this corpus — findings,\n' "$fp_candidates"
+    # This line used to read `... not this PR%s problem.\n' "'s"`, written that
+    # way to route an apostrophe around a known bashrs bug. bashrs 6.67.0
+    # reported SC1078 on it anyway — "did you forget to close this
+    # double-quoted string?" — and was wrong; the string was closed. The T4
+    # false positive this gate exists to retire, fired on the gate itself.
+    #
+    # It is now plain prose with no apostrophe, so the specimen is GONE from
+    # this file. That is a workaround, not a fix, and it is recorded here rather
+    # than left silent: the bug is T4, tracked in bashrs-tickets.md, and the
+    # honest home for a live specimen is a test fixture that must go green when
+    # T4 lands — not a comment claiming something the code no longer does.
+    printf 'not a gate failure. They are the next ticket, not this one.\n'
+fi
+printf '\nStill required in the PR body, and NOT checkable here:\n'
+printf '  - the CRUX comparison: how shellcheck / mvdan/sh / tree-sitter-bash\n'
+printf '    solve this, and where this fix diverges on purpose\n'
+printf '  - a written justification for any SCxxxx divergence from shellcheck\n'


### PR DESCRIPTION
Every fix to a false positive moves a rule's boundary, and a boundary can be moved too far. **The cheapest way to quiet a noisy rule is to make it wrong in the other direction**, and nothing in an ordinary review catches that — the diff looks like an improvement and the suite goes green.

This is the gate a lint-rule change passes *before* its PR exists. A gate that runs after the PR is a gate that gets argued with.

## Two halves, and the first outranks the second

**ADVERSARIAL — hunt the false negative.** Four committed fixtures of genuinely broken shell, each naming the rule that must flag it:

| fixture | must still fire |
|---|---|
| a quote that really runs to EOF | `SC1078` |
| a real shebang on line 6 | `SC1128` |
| a real bare redirection | `SC2188` |
| a variable really never assigned | `SC2154` |

If a lexer fix quiets one, the gate refuses the PR. A false positive is noise; **a false negative is a defect shipped under a green check.**

**CRUX — the competitive half.** shellcheck (Haskell, parser combinators) for how a heredoc body and a multi-line quote are *represented*; mvdan/sh (Go, documented AST) for command lists and word boundaries; tree-sitter-bash for partial input; clippy for lint namespacing. The write-up must say what the field does, what bashrs does, whether the fix matches or diverges, and where divergence is **defensible rather than a mistake to repeat**.

## Exit codes — the third is the one people get wrong

```
0  the gate RAN and the fix survived. Open the PR.
1  the fix FAILED a half. Do not open the PR.
2  the GATE could not run. NOTHING was measured. This is not a pass.
```

An absent shellcheck is not a clean bill of health.

It prints its denominator and counts `SEC`/`DET`/`IDEM` separately, so a falling error total can never hide those families going quiet — they found a real destructive-`rm` hazard in this corpus and are the reason to run the tool at all.

## Verified

```
GATE EXIT=0
must-still-fire: 4 checked, 4 fired, 0 LOST
differential: 45 script(s) scanned
              150 bashrs error(s) that BOTH shellcheck and bash -n accept
              117 SEC/DET/IDEM finding(s) still reported
```

That 150 is an independent reproduction of the corpus measurement, reached by a different method than the original count. `gate.sh` is itself clean under `bash -n`, `shellcheck -S error`, and `bashrs lint`.

## Three things it caught while being written, all kept

1. **`bashrs … | grep -q CODE` under `set -o pipefail`** — `grep -q` closes the pipe on its first match, SIGPIPEs bashrs, and the pipeline returns *that*. A **passing** check read as a failure, and all four fixtures reported `LOST`. Capture first, then match.
2. **A comment beginning `# shellcheck ` is parsed as a directive** — prose *about* shellcheck broke shellcheck with `SC1073`.
3. **bashrs reported `SC1078` on the gate's own `printf`** — the T4 false positive, firing on the gate built to retire it. Rewriting the line removed the specimen, so it now lives in `fixtures/t4-live-specimen.sh`, which must go **clean** when T4 lands. A comment claiming a specimen the code no longer contained would have been the same stale-comment defect this work keeps finding.

## How it is meant to be used

```
1. reproduce      the false positive, from the named file and line
2. fix            the cause, not the symptom
3. ADVERSARIAL    construct the false negative; prove the rule still fires
4. differential   bashrs vs shellcheck vs bash -n
5. CRUX           how the field solves it; where we diverge and why
6. denominators   corpus before/after, SEC/DET counts unchanged
7. THEN open the PR, with 3-6 in the body
```

A PR body without the must-still-fire evidence and the CRUX comparison has not passed this gate, whatever CI says.