### PR TITLE
fix(lint): an assignment after the first separator on a line was invisible, and a keyword matched as the prefix of a longer word (Refs #275)

### DIFF
--- a/rash/src/linter/rules/mod.rs
+++ b/rash/src/linter/rules/mod.rs
@@ -220,7 +220,11 @@ pub mod sc2151;
 pub mod sc2152;
 pub mod sc2153;
 pub mod sc2154;
+pub mod sc2154_assign;
 pub mod sc2154_logic;
+#[cfg(test)]
+#[path = "sc2154_tests_command_lists.rs"]
+mod sc2154_tests_command_lists;
 pub mod sc2155;
 pub mod sc2156;
 pub mod sc2157;

--- a/rash/src/linter/rules/sc1035.rs
+++ b/rash/src/linter/rules/sc1035.rs
@@ -24,6 +24,74 @@ const KEYWORDS: &[&str] = &[
     "then", "do", "else", "elif", "fi", "done", "while", "until", "for", "case", "esac", "in",
 ];
 
+/// Does `b` end a shell WORD?
+///
+/// GH-275. A word is "a sequence of characters treated as a unit by the shell",
+/// terminated only by an unquoted **metacharacter**: `| & ; ( ) < >` plus space,
+/// tab and newline. Every other byte — `-`, `.`, `/`, `$`, `=`, `:`, `*`, quotes
+/// — *continues* the word.
+///
+/// This rule used to treat any non-alphanumeric byte as a terminator, so it read
+/// `git for-each-ref` as the `for` keyword followed by `-each-ref` and reported a
+/// missing space in a line that `bash -n` and `shellcheck` both accept. Four of
+/// the 150 errors on the rmedia corpus were that one line shape.
+fn ends_shell_word(b: u8) -> bool {
+    matches!(
+        b,
+        b' ' | b'\t' | b'\n' | b'\r' | b'|' | b'&' | b';' | b'(' | b')' | b'<' | b'>'
+    )
+}
+
+/// Does a keyword butted directly against `b` mean a space is missing?
+///
+/// The correct spellings — a space, a tab, a newline, `;`, or a trailing `#`
+/// comment — are excluded, leaving the metacharacters that prove the shell ended
+/// the word right there. `{` and `}` are not POSIX metacharacters, but bash's
+/// parser rejects a keyword fused to one (`do{echo` is `syntax error near
+/// unexpected token 'do{'`), so they belong here too.
+///
+/// Deliberately NOT included: `$` and the quote characters. `echo done$count`
+/// and `echo done"$x"` are ordinary, correct shell — the keyword text is just
+/// the literal prefix of a word. That leaves `case$x in` (a genuine bash syntax
+/// error) unreported; shellcheck does not report SC1035 there either, and a
+/// false positive on every `done$n` in the fleet is the worse trade.
+fn indicates_missing_space(b: u8) -> bool {
+    matches!(b, b'(' | b')' | b'{' | b'}' | b'|' | b'&' | b'<' | b'>')
+}
+
+/// Is the `kw`-length token at `at` in `trimmed` a keyword fused to the next
+/// word — that is, does the shell end a word on both sides of it, with the
+/// right-hand side proving a space is missing?
+fn is_fused_keyword(trimmed: &str, at: usize, kw_len: usize) -> bool {
+    let bytes = trimmed.as_bytes();
+    let after = at + kw_len;
+
+    // The keyword must START a word: the shell has to have ended the previous
+    // word right before it. `--for(x)` is one word, so the `for` in it is not a
+    // keyword either.
+    let starts_word = at == 0 || ends_shell_word(bytes[at - 1]);
+
+    // ...and the shell must END the word right after it. Anything that continues
+    // the word (`-`, `.`, `/`, `_`, alphanumerics) means this is a longer word
+    // that merely begins with the keyword's letters — `for-each-ref`,
+    // `done.txt`, `done_flag`.
+    starts_word && after < bytes.len() && indicates_missing_space(bytes[after])
+}
+
+/// Every position in `trimmed` where `kw` appears fused to the next word.
+fn fused_positions(trimmed: &str, kw: &str) -> Vec<usize> {
+    let mut hits = Vec::new();
+    let mut search_start = 0;
+    while let Some(pos) = trimmed[search_start..].find(kw) {
+        let at = search_start + pos;
+        if is_fused_keyword(trimmed, at, kw.len()) {
+            hits.push(at);
+        }
+        search_start = at + kw.len();
+    }
+    hits
+}
+
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
 
@@ -34,45 +102,17 @@ pub fn check(source: &str) -> LintResult {
         if trimmed.starts_with('#') || trimmed.is_empty() {
             continue;
         }
+        let line_offset = line.find(trimmed).unwrap_or(0);
 
         for kw in KEYWORDS {
-            // Search for keyword followed immediately by a non-whitespace, non-semicolon char
-            let kw_len = kw.len();
-            let mut search_start = 0;
-
-            while let Some(pos) = trimmed[search_start..].find(kw) {
-                let abs_pos = search_start + pos;
-                let after = abs_pos + kw_len;
-
-                // Verify it's a word boundary before the keyword
-                let is_word_start = abs_pos == 0
-                    || !trimmed.as_bytes()[abs_pos - 1].is_ascii_alphanumeric()
-                        && trimmed.as_bytes()[abs_pos - 1] != b'_';
-
-                if is_word_start && after < trimmed.len() {
-                    let next_char = trimmed.as_bytes()[after];
-                    // Must be followed by something that's not whitespace, semicolon, newline, or #
-                    if next_char != b' '
-                        && next_char != b'\t'
-                        && next_char != b';'
-                        && next_char != b'\n'
-                        && next_char != b'#'
-                        && next_char != b'\r'
-                        // Also skip if next char is alphanumeric (it's part of a longer word, e.g. "done_flag")
-                        && !(next_char.is_ascii_alphanumeric() || next_char == b'_')
-                    {
-                        let line_offset = line.find(trimmed).unwrap_or(0);
-                        let col = line_offset + abs_pos + 1;
-                        result.add(Diagnostic::new(
-                            "SC1035",
-                            Severity::Error,
-                            format!("Missing space after '{}' keyword", kw),
-                            Span::new(line_num, col, line_num, col + kw_len),
-                        ));
-                    }
-                }
-
-                search_start = abs_pos + kw_len;
+            for at in fused_positions(trimmed, kw) {
+                let col = line_offset + at + 1;
+                result.add(Diagnostic::new(
+                    "SC1035",
+                    Severity::Error,
+                    format!("Missing space after '{}' keyword", kw),
+                    Span::new(line_num, col, line_num, col + kw.len()),
+                ));
             }
         }
     }
@@ -127,5 +167,97 @@ mod tests {
     fn test_sc1035_else_no_space() {
         let result = check("else(echo fallback)");
         assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    // ---- GH-275: keyword matching must respect shell word boundaries ----
+    //
+    // A shell WORD is terminated by an unquoted metacharacter. `for-each-ref`
+    // is ONE word, so the `for` in it is not the `for` keyword. The rule used
+    // to treat every non-alphanumeric byte as a word terminator, so `-`, `.`,
+    // `/` and `$` all split a word that the shell does not split.
+
+    #[test]
+    fn test_sc1035_git_for_each_ref_not_flagged() {
+        // rmedia scripts/local-state-snapshot.sh:68 — 4 findings in that file,
+        // all this shape. `bash -n` and `shellcheck` are both clean on it.
+        let result =
+            check("heads=$(git for-each-ref --format='%(objectname) %(refname:short)' refs/heads)");
+        assert_eq!(result.diagnostics.len(), 0, "{:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn test_sc1035_hyphen_continues_the_word() {
+        for line in [
+            "git for-each-ref refs/heads",
+            "do-release-upgrade --help",
+            "case-insensitive-sort < in.txt",
+            "esac-like-name --flag",
+            "in-place-edit file",
+        ] {
+            let result = check(line);
+            assert_eq!(
+                result.diagnostics.len(),
+                0,
+                "{line} -> {:?}",
+                result.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn test_sc1035_dot_and_slash_continue_the_word() {
+        for line in [
+            "ls /var/log/done.txt",
+            "rm -f while.tmp",
+            "source ./then.sh",
+            "cat /etc/case.conf",
+        ] {
+            let result = check(line);
+            assert_eq!(
+                result.diagnostics.len(),
+                0,
+                "{line} -> {:?}",
+                result.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn test_sc1035_dollar_continues_the_word() {
+        // `echo done$count` prints "done5". Nothing is missing here.
+        let result = check("echo done$count");
+        assert_eq!(result.diagnostics.len(), 0, "{:?}", result.diagnostics);
+    }
+
+    // ---- MUST STILL FIRE ----
+
+    #[test]
+    fn test_sc1035_must_still_fire_metacharacters() {
+        // Each of these is a metacharacter: the shell ends the word there, so
+        // the keyword really is a keyword and really is missing its space.
+        for line in [
+            "if true; then(echo hi)",
+            "else(echo fallback)",
+            "for i in 1 2; do{echo $i;}",
+            "if true; then|echo hi",
+            "if true; then&echo hi",
+            "while(true); do break; done",
+        ] {
+            let result = check(line);
+            assert!(
+                result.diagnostics.iter().any(|d| d.code == "SC1035"),
+                "SC1035 stopped firing on a genuine defect: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sc1035_must_still_fire_c_style_for() {
+        let result = check("for((i=0;i<3;i++)); do echo $i; done");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == "SC1035"),
+            "{:?}",
+            result.diagnostics
+        );
     }
 }

--- a/rash/src/linter/rules/sc2154_assign.rs
+++ b/rash/src/linter/rules/sc2154_assign.rs
@@ -1,0 +1,317 @@
+//! Which names does one physical line assign?
+//!
+//! GH-275. SC2154 used to answer this with
+//!
+//! ```text
+//! ^\s*(?:(?:local|readonly|export|declare|typeset)(?:\s+-[a-zA-Z]+)?\s+)?([A-Za-z_][A-Za-z0-9_]*)=
+//! ```
+//!
+//! anchored at `^`, so `captures_iter` could match at most once per line. A
+//! `;`-, `&&`- or `||`-separated list registered only its first assignment,
+//! `local a=1 b=2` registered only `a`, and a one-line function body registered
+//! nothing at all — the anchor never got past `f() {`. Everything it missed came
+//! back as "referenced but not assigned": 143 findings on the rmedia corpus,
+//! where `shellcheck` reports none.
+//!
+//! Deleting the anchor is the wrong fix. An unanchored `([A-Za-z_]\w*)=` reads
+//! `grep --color=auto` as an assignment to `color` and `echo "x=1"` as one to
+//! `x`, so SC2154 would go blind on those two variables — a false negative
+//! bought with a false positive, which for a linter is the worse direction.
+//!
+//! What makes `NAME=` an assignment is its POSITION: the shell honours it only
+//! at the start of a simple command, or in the assignment-prefix run that leads
+//! one. So this scans the line the way the shell reads it — tracking quoting and
+//! expansions, and tracking where each command begins — and reports a name only
+//! from a word the shell would itself treat as an assignment.
+
+/// Commands after which the remaining words are still declarations, so `NAME=`
+/// keeps its meaning: `local a=1 b=2`, `declare -i n=1 m=2`.
+const DECLARATION_BUILTINS: &[&str] = &["local", "readonly", "export", "declare", "typeset"];
+
+/// Reserved words that introduce a command rather than being one, so the word
+/// after them still begins a simple command: `if true; then c=1; fi`.
+const COMMAND_INTRODUCERS: &[&str] = &[
+    "then", "else", "elif", "do", "if", "while", "until", "!", "time", "{", "}",
+];
+
+/// One lexed unit of a line.
+enum Token {
+    /// A word, with quoted stretches replaced by NUL so their contents cannot
+    /// be mistaken for syntax.
+    Word(String),
+    /// `;`, `&`, `|`, `(`, `)`, `` ` `` — the next word starts a new command.
+    Separator,
+}
+
+/// The name assigned by `word`, if the shell would read it as an assignment.
+///
+/// Accepts `NAME=…`, `NAME+=…` and `NAME[subscript]=…`. Rejects a word whose `=`
+/// is not preceded by a whole valid name — `--color=auto`, `-o=x`, `=1`, `2x=1`.
+pub fn assigned_name(word: &str) -> Option<&str> {
+    let bytes = word.as_bytes();
+
+    if !bytes
+        .first()
+        .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+    {
+        return None;
+    }
+    let mut i = 0;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    let name = &word[..i];
+
+    // An optional array subscript: `q[0]=1`, `map[$k]=v`.
+    if bytes.get(i) == Some(&b'[') {
+        match word[i..].find(']') {
+            Some(close) => i += close + 1,
+            None => return None,
+        }
+    }
+    // An optional append: `p+=2`.
+    if bytes.get(i) == Some(&b'+') {
+        i += 1;
+    }
+
+    (bytes.get(i) == Some(&b'=')).then_some(name)
+}
+
+/// Consume a `${…}` / `$(…)` expansion starting at `bytes[i]` (which is `$`),
+/// returning the index just past it. Expansions are word text, not separators:
+/// the `}` in `repo=${1:-}` does not end a command.
+fn skip_expansion(bytes: &[u8], i: usize) -> usize {
+    let (open, close) = match bytes.get(i + 1) {
+        Some(b'{') => (b'{', b'}'),
+        Some(b'(') => (b'(', b')'),
+        _ => return i + 1,
+    };
+    let mut depth = 0usize;
+    let mut j = i + 1;
+    while j < bytes.len() {
+        if bytes[j] == open {
+            depth += 1;
+        } else if bytes[j] == close {
+            depth -= 1;
+            if depth == 0 {
+                return j + 1;
+            }
+        }
+        j += 1;
+    }
+    bytes.len()
+}
+
+/// Consume a quoted region starting at `bytes[i]` (the opening quote),
+/// returning the index just past the closing quote.
+fn skip_quoted(bytes: &[u8], i: usize) -> usize {
+    let quote = bytes[i];
+    let mut j = i + 1;
+    while j < bytes.len() {
+        if bytes[j] == b'\\' && quote == b'"' {
+            j += 2;
+            continue;
+        }
+        if bytes[j] == quote {
+            return j + 1;
+        }
+        j += 1;
+    }
+    bytes.len()
+}
+
+/// Lex one physical line into words and command separators.
+///
+/// Quoted stretches are collapsed to a NUL placeholder rather than scanned: the
+/// `=` in `echo "x=1"` is text, and reading it as an assignment is precisely the
+/// false negative this module exists to prevent. The placeholder is kept (rather
+/// than dropped) so `x"=1"` stays a single word that does not look like a bare
+/// `x=` assignment.
+fn lex(line: &str) -> Vec<Token> {
+    let bytes = line.as_bytes();
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut i = 0;
+
+    macro_rules! flush {
+        () => {
+            if !cur.is_empty() {
+                out.push(Token::Word(std::mem::take(&mut cur)));
+            }
+        };
+    }
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                cur.push('\\');
+                i += 2;
+            }
+            b'\'' | b'"' => {
+                let end = skip_quoted(bytes, i);
+                cur.push('\u{0}');
+                i = end;
+            }
+            b'$' => {
+                let end = skip_expansion(bytes, i);
+                cur.push_str(&line[i..end]);
+                i = end;
+            }
+            // A trailing comment, but only where a word could have started:
+            // the `#` in `curl http://x#y` is word text.
+            b'#' if cur.is_empty() => break,
+            b' ' | b'\t' => {
+                flush!();
+                i += 1;
+            }
+            b';' | b'&' | b'|' | b'(' | b')' | b'`' => {
+                flush!();
+                out.push(Token::Separator);
+                i += 1;
+            }
+            // `{` and `}` are reserved WORDS, not metacharacters: they separate
+            // commands only when they stand alone. Inside a word they are brace
+            // expansion (`cp f{,.bak}`) and must not split it.
+            b'{' | b'}' if cur.is_empty() => {
+                let next = bytes.get(i + 1);
+                if next.is_none() || matches!(next, Some(b' ' | b'\t' | b';')) {
+                    out.push(Token::Separator);
+                } else {
+                    cur.push(bytes[i] as char);
+                }
+                i += 1;
+            }
+            // Redirections end a word without starting a new command.
+            b'<' | b'>' => {
+                flush!();
+                i += 1;
+            }
+            b => {
+                cur.push(b as char);
+                i += 1;
+            }
+        }
+    }
+    flush!();
+    out
+}
+
+/// `mapfile`/`readarray` options that consume the word after them, so the array
+/// name is not mistaken for an option argument. `-t` takes none.
+const MAPFILE_OPTS_WITH_ARG: &[&str] = &["-d", "-n", "-O", "-s", "-u", "-C", "-c"];
+
+/// The array `mapfile`/`readarray` fills, given the words that follow it.
+///
+/// `mapfile -t names < <(…)` assigns `names`; with no name given it assigns
+/// `MAPFILE`, which is already a known builtin, so `None` is the right answer
+/// there too.
+fn mapfile_target(rest: &[&str]) -> Option<String> {
+    let mut i = 0;
+    while i < rest.len() {
+        let w = rest[i];
+        if MAPFILE_OPTS_WITH_ARG.contains(&w) {
+            i += 2;
+        } else if w.starts_with('-') && w.len() > 1 {
+            i += 1;
+        } else {
+            return is_name(w).then(|| w.to_string());
+        }
+    }
+    None
+}
+
+/// Is `w` a bare, valid variable name?
+fn is_name(w: &str) -> bool {
+    w.as_bytes()
+        .first()
+        .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
+        && w.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+/// What one word in command position does to the scan.
+enum Step {
+    /// It assigns this name, and the command position stays open.
+    Assigns(String),
+    /// It keeps the command position open but assigns nothing
+    /// (`local`, `then`, a flag to a declaration builtin).
+    KeepsOpen,
+    /// It is the command word: the position closes until the next separator.
+    Closes,
+}
+
+/// The words of the command `tokens[from..]` begins, up to its separator.
+fn command_words(tokens: &[Token], from: usize) -> Vec<&str> {
+    tokens[from..]
+        .iter()
+        .map_while(|t| match t {
+            Token::Word(w) => Some(w.as_str()),
+            Token::Separator => None,
+        })
+        .collect()
+}
+
+/// Classify `word`, which is known to sit in command position.
+fn classify(word: &str, in_declaration: bool, rest: &[&str]) -> Step {
+    if let Some(name) = assigned_name(word) {
+        // An assignment prefix does not consume the command position:
+        // `A=1 B=2 cmd` assigns twice.
+        return Step::Assigns(name.to_string());
+    }
+    if DECLARATION_BUILTINS.contains(&word) || COMMAND_INTRODUCERS.contains(&word) {
+        return Step::KeepsOpen;
+    }
+    // `declare -i n=1` — a flag to a declaration builtin keeps it open.
+    if in_declaration && word.starts_with('-') {
+        return Step::KeepsOpen;
+    }
+    // `mapfile`/`readarray` name their array as a plain argument rather than
+    // with `=`, and only when it is the command word: the `mapfile` inside
+    // `echo 'use mapfile -t out'` is a quoted message the lexer has already
+    // collapsed to a placeholder.
+    if matches!(word, "mapfile" | "readarray") {
+        if let Some(name) = mapfile_target(rest) {
+            return Step::Assigns(name);
+        }
+    }
+    Step::Closes
+}
+
+/// Every variable name `line` assigns.
+///
+/// Known and accepted imprecision: an array literal whose ELEMENTS look like
+/// assignments (`arr=(x=1 y=2)`) also registers `x` and `y`. It is rare, and it
+/// can only make SC2154 quieter on those two names — never on anything else.
+pub fn line_assignments(line: &str) -> Vec<String> {
+    let tokens = lex(line);
+    let mut assigned = Vec::new();
+    let mut at_command_start = true;
+    let mut in_declaration = false;
+
+    for (i, token) in tokens.iter().enumerate() {
+        let word = match token {
+            Token::Separator => {
+                at_command_start = true;
+                in_declaration = false;
+                continue;
+            }
+            Token::Word(w) => w.as_str(),
+        };
+        if !at_command_start {
+            continue;
+        }
+
+        match classify(word, in_declaration, &command_words(&tokens, i + 1)) {
+            Step::Assigns(name) => assigned.push(name),
+            Step::KeepsOpen => in_declaration |= DECLARATION_BUILTINS.contains(&word),
+            Step::Closes => {
+                at_command_start = false;
+                in_declaration = false;
+            }
+        }
+    }
+    assigned
+}
+
+#[cfg(test)]
+#[path = "sc2154_assign_tests.rs"]
+mod tests;

--- a/rash/src/linter/rules/sc2154_assign_tests.rs
+++ b/rash/src/linter/rules/sc2154_assign_tests.rs
@@ -1,0 +1,166 @@
+//! Unit tests for the assignment scanner (GH-272).
+
+use super::*;
+
+fn a(line: &str) -> Vec<String> {
+    line_assignments(line)
+}
+
+// ===== assigned_name: what shape is an assignment word =====
+
+#[test]
+fn assigned_name_accepts_the_real_shapes() {
+    assert_eq!(assigned_name("x=1"), Some("x"));
+    assert_eq!(assigned_name("_x=1"), Some("_x"));
+    assert_eq!(assigned_name("x9=1"), Some("x9"));
+    assert_eq!(assigned_name("x="), Some("x"));
+    assert_eq!(assigned_name("p+=2"), Some("p"));
+    assert_eq!(assigned_name("q[0]=1"), Some("q"));
+    assert_eq!(assigned_name("map[$k]=v"), Some("map"));
+    assert_eq!(assigned_name("arr+=(a)"), Some("arr"));
+}
+
+#[test]
+fn assigned_name_rejects_everything_that_is_not_one() {
+    assert_eq!(assigned_name("--color=auto"), None);
+    assert_eq!(assigned_name("-o=x"), None);
+    assert_eq!(assigned_name("=1"), None);
+    assert_eq!(assigned_name("2x=1"), None);
+    assert_eq!(assigned_name("x"), None);
+    assert_eq!(assigned_name("x.y=1"), None);
+    assert_eq!(assigned_name("q[0=1"), None);
+    assert_eq!(assigned_name(""), None);
+}
+
+// ===== command position =====
+
+#[test]
+fn only_the_command_position_counts() {
+    assert_eq!(a("x=1"), ["x"]);
+    assert!(a("echo x=1").is_empty());
+    assert!(a("grep --color=auto q").is_empty());
+    assert!(a("[ \"$z\" = 1 ]").is_empty());
+}
+
+#[test]
+fn separators_reopen_the_command_position() {
+    assert_eq!(a("a=1; b=2"), ["a", "b"]);
+    assert_eq!(a("a=1;b=2;c=3"), ["a", "b", "c"]);
+    assert_eq!(a("a=1 && b=2"), ["a", "b"]);
+    assert_eq!(a("a=1 || b=2"), ["a", "b"]);
+    assert_eq!(a("a=1 & b=2"), ["a", "b"]);
+    assert_eq!(a("a=1; ( b=2 )"), ["a", "b"]);
+    assert_eq!(a("a=1; { b=2; }"), ["a", "b"]);
+}
+
+#[test]
+fn a_command_word_closes_the_position_until_the_next_separator() {
+    // `b=2` is an argument to echo; `c=3` starts a fresh command.
+    assert_eq!(a("a=1; echo b=2; c=3"), ["a", "c"]);
+}
+
+#[test]
+fn assignment_prefixes_stack() {
+    assert_eq!(a("A=1 B=2 env"), ["A", "B"]);
+    assert!(a("A=1 env B=2").len() == 1);
+}
+
+#[test]
+fn declaration_builtins_take_several_names() {
+    assert_eq!(
+        a("local name=$1 expect=$2 body=$3"),
+        ["name", "expect", "body"]
+    );
+    assert_eq!(a("export A=1 B=2"), ["A", "B"]);
+    assert_eq!(a("declare -i n=1 m=2"), ["n", "m"]);
+    assert_eq!(a("readonly -r t=1"), ["t"]);
+}
+
+#[test]
+fn control_keywords_do_not_close_the_command_position() {
+    assert_eq!(a("if true; then c=1; fi"), ["c"]);
+    assert_eq!(a("for i in 1 2; do d=1; done"), ["d"]);
+    assert_eq!(a("if false; then :; else e=1; fi"), ["e"]);
+    assert_eq!(a("case x in x) g=1 ;; esac"), ["g"]);
+}
+
+#[test]
+fn a_one_line_function_body_is_reached() {
+    assert_eq!(a("f() { local x=$1 y=$2; echo \"$x$y\"; }"), ["x", "y"]);
+}
+
+// ===== quoting and expansion =====
+
+#[test]
+fn quoted_text_is_never_an_assignment() {
+    assert!(a("echo \"x=1\"").is_empty());
+    assert!(a("echo 'y=1'").is_empty());
+    assert!(a("printf '%s' \"a=1;b=2\"").is_empty());
+}
+
+#[test]
+fn an_expansion_does_not_split_the_word() {
+    // `${1:-}` closes with `}`; that brace must not read as a command separator
+    // or `course` and `delete` go missing. This is the rmedia line verbatim.
+    assert_eq!(
+        a("repo=${1:-}; course=${2:-}; delete=${3:-}"),
+        ["repo", "course", "delete"]
+    );
+    assert_eq!(a("dir=$(mktemp -d); marker=\"$dir/n\""), ["dir", "marker"]);
+    assert_eq!(a("n=$((1 + 2)); m=3"), ["n", "m"]);
+}
+
+#[test]
+fn a_trailing_comment_is_not_scanned() {
+    assert_eq!(a("a=1  # b=2"), ["a"]);
+    assert!(a("curl http://x#y=1").is_empty());
+}
+
+#[test]
+fn brace_expansion_does_not_split_a_word() {
+    assert!(a("cp file{,.bak}").is_empty());
+}
+
+#[test]
+fn redirections_end_a_word_without_opening_a_command() {
+    assert_eq!(a("a=1 >out"), ["a"]);
+    assert!(a("echo hi >out b=2").is_empty());
+}
+
+#[test]
+fn unterminated_quote_or_expansion_does_not_panic() {
+    let _ = a("a=\"unterminated");
+    let _ = a("a=${unterminated");
+    let _ = a("a=$(unterminated");
+    let _ = a("a='");
+    let _ = a("\\");
+}
+
+// ===== mapfile / readarray =====
+
+#[test]
+fn mapfile_names_its_array() {
+    assert_eq!(a("mapfile -t names < <(ls)"), ["names"]);
+    assert_eq!(a("readarray -t rows < <(ls)"), ["rows"]);
+    assert_eq!(a("mapfile arr < f"), ["arr"]);
+}
+
+#[test]
+fn mapfile_option_arguments_are_not_the_array() {
+    assert_eq!(
+        a("mapfile -d '' -n 5 -O 1 -s 2 -u 3 -C cb -c 4 -t arr < f"),
+        ["arr"]
+    );
+}
+
+#[test]
+fn mapfile_without_a_name_assigns_nothing_explicit() {
+    // The implicit target is MAPFILE, already a known builtin.
+    assert!(a("mapfile -t < <(ls)").is_empty());
+}
+
+#[test]
+fn mapfile_only_counts_as_the_command_word() {
+    assert!(a("echo mapfile -t out").is_empty());
+    assert!(a("echo 'use mapfile -t out'").is_empty());
+}

--- a/rash/src/linter/rules/sc2154_logic.rs
+++ b/rash/src/linter/rules/sc2154_logic.rs
@@ -160,27 +160,23 @@ pub fn is_special_or_builtin(var_name: &str, builtins: &HashSet<&str>) -> bool {
 /// Check if script sources external files
 /// If source/. commands are found, we're more lenient with undefined variables
 pub fn has_source_commands(source: &str) -> bool {
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('#') {
-            continue;
-        }
-        // Match: source file, . file, source "file", . "file"
-        if trimmed.starts_with("source ") || trimmed.starts_with(". ") {
-            return true;
-        }
-        // Also check for source/. after semicolon or &&/||
-        if trimmed.contains("; source ")
-            || trimmed.contains("; . ")
-            || trimmed.contains("&& source ")
-            || trimmed.contains("&& . ")
-            || trimmed.contains("|| source ")
-            || trimmed.contains("|| . ")
-        {
-            return true;
-        }
-    }
-    false
+    /// `source`/`.` reached after a command separator on the same line.
+    const AFTER_SEPARATOR: &[&str] = &[
+        "; source ",
+        "; . ",
+        "&& source ",
+        "&& . ",
+        "|| source ",
+        "|| . ",
+    ];
+
+    source.lines().map(str::trim).any(|trimmed| {
+        !trimmed.starts_with('#')
+            // Match: source file, . file, source "file", . "file"
+            && (trimmed.starts_with("source ")
+                || trimmed.starts_with(". ")
+                || AFTER_SEPARATOR.iter().any(|s| trimmed.contains(s)))
+    })
 }
 
 /// Check if line is a comment
@@ -317,42 +313,37 @@ pub fn is_case_pattern_line(line: &str) -> bool {
     t.ends_with(')') && !t.contains('=')
 }
 
+/// Index of the first word after `read`'s option run.
+fn skip_read_flags(parts: &[&str]) -> usize {
+    let mut i = 0;
+    while parts.get(i).is_some_and(|p| p.starts_with('-')) {
+        // These options take a value, which is not a variable name.
+        let takes_arg = matches!(parts[i], "-p" | "-a" | "-d" | "-n" | "-t" | "-u");
+        i += if takes_arg { 2 } else { 1 };
+    }
+    i
+}
+
+/// Is `word` a bare, valid variable name?
+fn is_plain_name(word: &str) -> bool {
+    word.chars()
+        .next()
+        .is_some_and(|c| c.is_alphabetic() || c == '_')
+        && word.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
 /// Extract variable names from read command in a line
 pub fn extract_read_variables(line: &str) -> Vec<String> {
-    let mut vars = Vec::new();
-    if let Some(read_pos) = line.find("read ") {
-        let after_read = &line[read_pos + 5..];
-        let parts: Vec<&str> = after_read.split_whitespace().collect();
-        let mut i = 0;
-        // Skip flags
-        while i < parts.len() {
-            let part = parts[i];
-            if part.starts_with('-') {
-                i += 1;
-                if matches!(part, "-p" | "-a" | "-d" | "-n" | "-t" | "-u") {
-                    i += 1;
-                }
-            } else {
-                break;
-            }
-        }
-        // Remaining parts are variable names
-        while i < parts.len() {
-            let var_name = parts[i].trim_end_matches(';');
-            if var_name
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_alphabetic() || c == '_')
-                && var_name.chars().all(|c| c.is_alphanumeric() || c == '_')
-            {
-                vars.push(var_name.to_string());
-                i += 1;
-            } else {
-                break;
-            }
-        }
-    }
-    vars
+    let Some(read_pos) = line.find("read ") else {
+        return Vec::new();
+    };
+    let parts: Vec<&str> = line[read_pos + 5..].split_whitespace().collect();
+    parts[skip_read_flags(&parts).min(parts.len())..]
+        .iter()
+        .map(|p| p.trim_end_matches(';'))
+        .take_while(|p| is_plain_name(p))
+        .map(str::to_string)
+        .collect()
 }
 
 /// Patterns for variable detection
@@ -394,39 +385,61 @@ pub fn collect_variable_info(
             continue;
         }
 
-        for cap in patterns.assign.captures_iter(line) {
-            assigned.insert(cap.get(1).unwrap().as_str().to_string());
+        for name in collect_line_assignments(line, patterns) {
+            assigned.insert(name);
         }
-        for cap in patterns.for_loop.captures_iter(line) {
-            assigned.insert(cap.get(1).unwrap().as_str().to_string());
-        }
-        for cap in patterns.c_style_for.captures_iter(line) {
-            assigned.insert(cap.get(1).unwrap().as_str().to_string());
-        }
-        for cap in patterns.case_expr.captures_iter(line) {
-            assigned.insert(cap.get(1).unwrap().as_str().to_string());
-        }
-        for var in extract_read_variables(line) {
-            assigned.insert(var);
-        }
-        for cap in patterns.use_.captures_iter(line) {
-            let var_name = cap.get(1).unwrap().as_str();
-            let full_match = cap.get(0).unwrap();
-            let col = full_match.start() + 1;
-
-            // Issue #132: Skip variables with parameter expansion operators
-            // ${VAR:-}, ${VAR:=}, ${VAR:+}, ${VAR:?} are intentional default/check patterns
-            if is_parameter_expansion_with_operator(line, full_match.end()) {
-                continue;
-            }
-
-            if has_sources && is_uppercase_var(var_name) {
-                continue;
-            }
-            used_vars.push((var_name.to_string(), line_num, col));
-        }
+        collect_line_uses(line, line_num, patterns, has_sources, &mut used_vars);
     }
     (assigned, used_vars)
+}
+
+/// Every name assigned on one line, by any recognised form.
+#[allow(clippy::unwrap_used)] // Regex captures in known patterns
+fn collect_line_assignments(line: &str, patterns: &Patterns) -> Vec<String> {
+    // GH-275: not `patterns.assign`. That regex is anchored at `^\s*`, so it
+    // could only ever see the first assignment on a line — everything after a
+    // `;`, `&&` or `||`, and every extra name on a `local a=1 b=2`, was reported
+    // as unassigned. See `sc2154_assign` for why an unanchored regex is not the
+    // fix either.
+    let mut names = crate::linter::rules::sc2154_assign::line_assignments(line);
+    for pattern in [
+        &patterns.for_loop,
+        &patterns.c_style_for,
+        &patterns.case_expr,
+    ] {
+        for cap in pattern.captures_iter(line) {
+            names.push(cap.get(1).unwrap().as_str().to_string());
+        }
+    }
+    names.extend(extract_read_variables(line));
+    names
+}
+
+/// Every variable REFERENCE on one line, appended to `used_vars`.
+#[allow(clippy::unwrap_used)] // Regex captures in known patterns
+fn collect_line_uses(
+    line: &str,
+    line_num: usize,
+    patterns: &Patterns,
+    has_sources: bool,
+    used_vars: &mut Vec<(String, usize, usize)>,
+) {
+    for cap in patterns.use_.captures_iter(line) {
+        let var_name = cap.get(1).unwrap().as_str();
+        let full_match = cap.get(0).unwrap();
+        let col = full_match.start() + 1;
+
+        // Issue #132: Skip variables with parameter expansion operators
+        // ${VAR:-}, ${VAR:=}, ${VAR:+}, ${VAR:?} are intentional default/check patterns
+        if is_parameter_expansion_with_operator(line, full_match.end()) {
+            continue;
+        }
+
+        if has_sources && is_uppercase_var(var_name) {
+            continue;
+        }
+        used_vars.push((var_name.to_string(), line_num, col));
+    }
 }
 
 /// Validate undefined variables and return diagnostics info

--- a/rash/src/linter/rules/sc2154_tests_command_lists.rs
+++ b/rash/src/linter/rules/sc2154_tests_command_lists.rs
@@ -1,0 +1,207 @@
+//! GH-275: an assignment is not always the first thing on its line.
+//!
+//! `collect_variable_info` found assignments with a regex anchored to `^\s*`,
+//! so `captures_iter` could only ever match once, at the start of the line.
+//! Every assignment after the first separator on a line was invisible, and the
+//! variable it defined was then reported as "referenced but not assigned":
+//!
+//! ```sh
+//! repo=${1:-}; course=${2:-}; delete=${3:-}   # only `repo` registered
+//! ```
+//!
+//! 143 of the 150 SC2154 findings on the rmedia corpus were this. `shellcheck`
+//! reports none of them; it is the reference implementation for the SCxxxx
+//! namespace and every case below was checked against it.
+//!
+//! The must-not-regress direction matters more than the count: widening the
+//! search must not start reading `--color=auto` or a quoted `"x=1"` as an
+//! assignment, because that would trade these false positives for SC2154 going
+//! blind on a genuinely unassigned variable.
+
+use super::sc2154::check;
+
+fn flagged(src: &str) -> Vec<String> {
+    check(src)
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "SC2154")
+        .map(|d| d.message.split('\'').nth(1).unwrap_or_default().to_string())
+        .collect()
+}
+
+fn assert_clean(src: &str) {
+    let got = flagged(src);
+    assert!(got.is_empty(), "SC2154 false positive on {src:?}: {got:?}");
+}
+
+// ===== the separators =====
+
+#[test]
+fn semicolon_separated_assignments_are_all_tracked() {
+    // rmedia scripts/archive-delivered-course.sh:36
+    assert_clean("repo=${1:-}; course=${2:-}; delete=${3:-}\necho \"$repo$course$delete\"");
+}
+
+#[test]
+fn semicolon_without_spaces() {
+    assert_clean("a=1;b=2;c=3\necho \"$a$b$c\"");
+}
+
+#[test]
+fn andand_and_oror_separated_assignments() {
+    assert_clean("a=1 && b=2\necho \"$a$b\"");
+    assert_clean("a=1 || b=2\necho \"$a$b\"");
+    assert_clean("a=1 && b=2 || c=3\necho \"$a$b$c\"");
+}
+
+#[test]
+fn newline_separated_assignments_still_work() {
+    assert_clean("a=1\nb=2\necho \"$a$b\"");
+}
+
+#[test]
+fn assignments_inside_a_brace_group_or_subshell() {
+    assert_clean("a=1; { b=2; }\necho \"$a$b\"");
+    assert_clean("a=1; ( b=2 )\necho \"$a$b\"");
+}
+
+#[test]
+fn assignment_after_a_control_keyword_on_one_line() {
+    assert_clean("if true; then c=1; fi\necho \"$c\"");
+    assert_clean("for i in 1 2; do d=1; done\necho \"$d\"");
+    assert_clean("if false; then :; else e=1; fi\necho \"$e\"");
+}
+
+#[test]
+fn assignment_in_a_case_branch_on_one_line() {
+    assert_clean("case x in x) g=1 ;; esac\necho \"$g\"");
+}
+
+// ===== the declaration builtins =====
+
+#[test]
+fn local_declares_several_variables_at_once() {
+    // rmedia scripts/falsify-ci-retry-classifier.sh:19
+    assert_clean("f() {\n  local name=$1 expect=$2 body=$3\n  echo \"$name$expect$body\"\n}");
+}
+
+#[test]
+fn declaration_builtins_on_a_single_line_function_body() {
+    // The `^\s*` anchor also lost the FIRST assignment whenever the line began
+    // with anything else — here, the function header.
+    assert_clean("f() { local x=$1 y=$2; echo \"$x$y\"; }");
+}
+
+#[test]
+fn local_then_assign_across_a_semicolon() {
+    // rmedia scripts/falsify-ci-retry-classifier.sh:20
+    assert_clean(
+        "f() {\n  local dir; dir=$(mktemp -d); local marker=\"$dir/n\"\n  echo \"$dir$marker\"\n}",
+    );
+}
+
+#[test]
+fn export_readonly_declare_typeset_with_flags() {
+    assert_clean("export A=1 B=2\necho \"$A$B\"");
+    assert_clean("readonly r=1 s=2\necho \"$r$s\"");
+    assert_clean("declare -i n=1 m=2\necho \"$n$m\"");
+    assert_clean("typeset -r t=1 u=2\necho \"$t$u\"");
+}
+
+#[test]
+fn assignment_prefixes_on_one_command() {
+    // `FOO=1 BAR=2 cmd` — both are assignments, cmd is not.
+    assert_clean("A=1 B=2 env >/dev/null\necho \"$A$B\"");
+}
+
+#[test]
+fn append_and_array_subscript_assignment() {
+    assert_clean("p=1; p+=2\necho \"$p\"");
+    assert_clean("q[0]=1; q[1]=2\necho \"${q[0]}\"");
+}
+
+// ===== MUST STILL FIRE =====
+//
+// Each of these is a variable `shellcheck` also reports. If widening the
+// assignment search silences any of them, the fix has traded a false positive
+// for a false negative and SC2154 is no longer trustworthy when it is red.
+
+#[test]
+fn must_still_fire_on_a_plainly_unassigned_variable() {
+    assert_eq!(flagged("echo \"$never_assigned\""), ["never_assigned"]);
+}
+
+#[test]
+fn must_still_fire_when_the_equals_is_inside_an_option_argument() {
+    // `--color=auto` is an argument to grep, NOT an assignment to `color`.
+    // This is the discriminating case for the whole fix: a naive unanchored
+    // `([A-Za-z_]\w*)=` regex passes every test above and fails this one.
+    assert_eq!(
+        flagged("grep --color=auto q /dev/null\necho \"$color\""),
+        ["color"]
+    );
+}
+
+#[test]
+fn must_still_fire_when_the_equals_is_inside_a_string_literal() {
+    assert_eq!(flagged("echo \"x=1\"\necho \"$x\""), ["x"]);
+    assert_eq!(flagged("echo 'y=1'\necho \"$y\""), ["y"]);
+}
+
+#[test]
+fn must_still_fire_when_the_equals_is_an_argument_word() {
+    // `echo a=1` prints the text "a=1"; it assigns nothing.
+    assert_eq!(flagged("echo a=1\necho \"$a\""), ["a"]);
+}
+
+#[test]
+fn must_still_fire_on_a_test_comparison() {
+    // `[ "$z" = 1 ]` is a comparison. `z` is still unassigned.
+    let got = flagged("[ \"$z\" = 1 ] && echo hi");
+    assert_eq!(got, ["z"]);
+}
+
+#[test]
+fn must_still_fire_for_a_variable_assigned_only_in_a_comment() {
+    assert_eq!(flagged("# c=1\necho \"$c\""), ["c"]);
+}
+
+// ===== `mapfile` / `readarray` assign too =====
+//
+// Same shape as the separator bug: an assignment form `collect_variable_info`
+// could not see. `read` was already handled; its array siblings were not, so
+// every `mapfile -t names < <(…)` left `names` looking unassigned. 9 of the 11
+// SC2154 findings left on the rmedia corpus were this. `shellcheck` reports
+// none of them.
+
+#[test]
+fn mapfile_and_readarray_assign_their_array() {
+    assert_clean("mapfile -t names < <(ls)\necho \"${names[0]}\"");
+    assert_clean("readarray -t rows < <(ls)\necho \"${rows[0]}\"");
+    // rmedia scripts/lint-contract-validity.sh:17
+    assert_clean("mapfile -t allow < <(grep -v '^#' f)\necho \"${allow[@]}\"");
+}
+
+#[test]
+fn mapfile_flags_that_take_an_argument_are_skipped() {
+    assert_clean("mapfile -d '' -n 5 -O 1 -s 2 -u 3 -C cb -c 4 -t arr < <(ls)\necho \"${arr[0]}\"");
+}
+
+#[test]
+fn mapfile_with_no_array_name_assigns_MAPFILE() {
+    assert_clean("mapfile -t < <(ls)\necho \"${MAPFILE[0]}\"");
+}
+
+#[test]
+fn must_still_fire_alongside_a_mapfile() {
+    // Widening to mapfile must not make the rule blind to its neighbours.
+    assert_eq!(
+        flagged("mapfile -t names < <(ls)\necho \"${names[0]}$ghost\""),
+        ["ghost"]
+    );
+}
+
+#[test]
+fn must_still_fire_when_mapfile_is_only_a_word_in_a_message() {
+    assert_eq!(flagged("echo 'use mapfile -t out'\necho \"$out\""), ["out"]);
+}


### PR DESCRIPTION
Closes #275.

Two independent false-positive defects found on the rmedia `scripts/*.sh` corpus (45 scripts), where `shellcheck` reports **0** SC2154 and `bash -n` is clean on every line below.

## SC2154 — 143 findings, now 2

`create_patterns().assign` is anchored at `^\s*`, so `captures_iter` could match at most **once per line**. Every assignment past the first separator was invisible and came back as "referenced but not assigned":

```sh
# rmedia scripts/archive-delivered-course.sh:36
repo=${1:-}; course=${2:-}; delete=${3:-}     # only `repo` registered
```

Same for `&&`, `||`, `&`, subshells, brace groups, and an assignment after a control keyword. And it was worse than "the first survives" — when the line began with anything else the anchor never got past it:

```sh
# rmedia scripts/falsify-ci-retry-classifier.sh:19
local name=$1 expect=$2 body=$3               # SC2154 on `expect` AND `body`
f() { local x=$1 y=$2; echo "$x$y"; }         # SC2154 on `x` AND `y` — NEITHER registered
```

**Deleting the anchor is the wrong fix.** An unanchored `([A-Za-z_]\w*)=` reads `grep --color=auto` as an assignment to `color` and `echo "x=1"` as one to `x`, so SC2154 would go *blind* on those. A false negative bought with a false positive is the worse direction for a linter.

What makes `NAME=` an assignment is its **position**: the shell honours it only at the start of a simple command, or in the assignment-prefix run leading one. The new `sc2154_assign` scans the line the way the shell reads it — tracking quoting, `${…}`/`$(…)` expansions, and where each command begins — and reports a name only from a word the shell would itself treat as an assignment.

`mapfile`/`readarray` are handled in the same pass: the same root shape (an assignment form the collector cannot see) that `read` was already handled for, and 9 of the 11 findings left after the separator fix.

## SC1035 — 4 findings, now 0

The rule treated any non-alphanumeric byte as a word terminator, but a shell word ends only at an unquoted **metacharacter** (`| & ; ( ) < >` plus whitespace). `-`, `.`, `/` and `$` continue a word:

```sh
# rmedia scripts/local-state-snapshot.sh:68,120,139,158
heads=$(git for-each-ref --format='%(objectname)' refs/heads)
#            ^^^ SC1035 [error]: Missing space after 'for' keyword

# infra machines/mini/bootstrap.sh:40,54
touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
#                                                         ^^ SC1035 [error] on 'in'
```

Both directions of the boundary are now checked against that set. `{`/`}` are kept in the "missing space" set although they are not POSIX metacharacters, because bash's parser rejects a keyword fused to one (`do{echo` is ``syntax error near unexpected token `do{'``).

**Deliberately NOT in that set: `$` and the quote characters.** `echo done$count` is ordinary correct shell. That leaves `case$x in` unreported; `shellcheck` does not report SC1035 there either, and a false positive on every `done$n` is the worse trade.

## Must still fire

Every rule touched keeps a must-still-fire case, and each was watched go **RED** before the fix (SC1035: 4 red, 2 must-still-fire already green; SC2154: 12 red, 7 must-still-fire already green). Proven end-to-end through the built binary, not only in unit tests:

- **SC1035** still fires on `then(`, `else(`, `do{`, `then|`, `then&`, `while(` and `for((i=0;i<3;i++))`.
- **SC2154** still fires on a plainly unassigned variable; on `--color=auto` (option argument); on a quoted `"x=1"` / `'y=1'` (string literal); on `echo a=1` (argument word); on `[ "$z" = 1 ]` (comparison); on a variable assigned only in a comment; and alongside a `mapfile`.
- **SEC011** still fires on the genuine `rm -rf "$src_raw"` hazard this corpus contains.

## Measured

rmedia `scripts/*.sh`, 45 scripts, this branch vs its branch point (`da7442c3d1`):

| | branch point | this branch |
|---|---|---|
| errors | 36 | **32** |
| SC1035 | 4 | **0** |
| SC2154 | 143 | **2** |
| SEC010 / SEC011 | 18 / 18 | 18 / 18 |
| DET002 / DET003 | 12 / 27 | 12 / 27 |

The SEC/DET row is the point: SEC011 caught a real `rm -rf` hazard in this corpus, and that signal was sitting under 147 false positives.

Across **120** infra `machines/**/*.sh`, SC1035 and SC2154 are the **only** codes that move (10572 → 10221 findings). Both infra SC1035 hits were the `.in-progress` shape, clean under `shellcheck` and `bash -n`.

## Notes for the reviewer

- **The 2 remaining SC2154 are a different, unfixed defect** and are left for a follow-up: `RATCHET` inside a single-quoted `sed` program and `CARGO_HOME` inside an escaped `\${…}` in a double-quoted string. SC2154 is not in `QUOTE_SENSITIVE_RULES`, so it reads string literals as code. Same for the ~69 left on the infra corpus, which are mostly `awk` program variables (`BEGIN`, `END`).
- **bashrs SC1035 diverges from shellcheck on what the code means.** shellcheck's SC1035 is "missing space after `!`"; bashrs uses it for "missing space after keyword". Not changed here — flagging it because the SCxxxx namespace is shellcheck's. shellcheck also accepts `then(echo hi)` (valid bash), which bashrs still reports; the existing test pins that behaviour, so this PR leaves it alone.
- **`rash/tests/cli_lint_exit_codes_tests.rs` has 2 tests already failing on `main`** (`test_issue_006_ci_cd_errors_fail`, `test_issue_006_exit_1_errors_and_warnings`). Verified by checking out `da7442c3d1` clean: both fail there identically. They depend on SC2188 firing on `> deploy.log`, which changed in #250. Not caused by, and not fixed by, this PR.
- Complexity was reduced to clear the pre-commit gate honestly rather than around it: `sc1035::check` was **already over threshold on main at 69** and is now under 25; `collect_variable_info` (35), `extract_read_variables` (32) and `has_source_commands` (28) were extracted. Behaviour-preserving — 15079 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMdV9icqNz2jis3rB2PaKQ