### PR TITLE
fix(lint): five rules read string literals, heredoc bodies and case patterns as shell code

### DIFF
--- a/rash/src/linter/quoting.rs
+++ b/rash/src/linter/quoting.rs
@@ -56,6 +56,9 @@ enum Ctx {
     Arith,
     /// Inside `$'...'` — literal, but `\'` is an escape, unlike `'...'`.
     Ansi,
+    /// Between `case … in` and `esac` — code. Tracked only so a pattern's `)`
+    /// is not mistaken for the close of an enclosing `$( … )`.
+    Case,
 }
 
 /// A pending or in-progress heredoc body.
@@ -84,6 +87,8 @@ pub struct QuotedRegions {
     /// are literal text by definition, so every rule is dropped there — see
     /// [`quoted_heredoc_lines`].
     quoted_heredoc: std::collections::HashSet<usize>,
+    /// 1-indexed lines inside ANY heredoc body, quoted delimiter or not.
+    heredoc_body: std::collections::HashSet<usize>,
 }
 
 impl QuotedRegions {
@@ -114,6 +119,7 @@ impl QuotedRegions {
             scanner
                 .quoted_heredoc
                 .retain(|line| *line < open.body_start);
+            scanner.heredoc_body.retain(|line| *line < open.body_start);
         }
         if let Some((line, col)) = discard_at {
             discard_from(&mut per_line, line, col);
@@ -124,6 +130,7 @@ impl QuotedRegions {
             per_line,
             any,
             quoted_heredoc: scanner.quoted_heredoc,
+            heredoc_body: scanner.heredoc_body,
         }
     }
 
@@ -176,6 +183,21 @@ pub fn quoted_heredoc_lines(source: &str) -> std::collections::HashSet<usize> {
     QuotedRegions::analyze(source).quoted_heredoc
 }
 
+/// 1-indexed lines inside ANY heredoc body, whether or not its delimiter was
+/// quoted.
+///
+/// For rules whose subject is a property of *the file being linted* rather than
+/// of the text — a shebang's position, say. A heredoc that writes a script is
+/// the ordinary way to emit one, and the emitted `#!` is on line 1 of the file
+/// being written, not a misplaced shebang in the writer.
+///
+/// Distinct from masking: a shebang lives in a comment, and comments are masked
+/// as literal text, so running such a rule on the masked source would blind it
+/// to genuinely misplaced shebangs too.
+pub fn heredoc_body_lines(source: &str) -> std::collections::HashSet<usize> {
+    QuotedRegions::analyze(source).heredoc_body
+}
+
 /// Rules whose subject is shell *syntax*, and which are therefore meaningless
 /// inside a string literal.
 ///
@@ -195,6 +217,8 @@ pub const QUOTE_SENSITIVE_RULES: &[&str] = &[
     // Function/parameter syntax — `function(a, b)` inside an awk or SQL program.
     "SC1065", // Function parameters in shell
     // Redirection/operator syntax appearing as text.
+    "SC2188", // Redirection without command — `<key>` in an embedded XML/plist
+    // fragment is data, not a redirection.
     "SC1007", // Remove space after = — `skip = 0` inside an awk program is awk
     "SC1014", // Use `if cmd; then`
     "SC1036", // ( is invalid here
@@ -346,6 +370,8 @@ struct Scanner {
     stack: Vec<Ctx>,
     /// 1-indexed lines inside a quoted-delimiter heredoc body.
     quoted_heredoc: std::collections::HashSet<usize>,
+    /// 1-indexed lines inside ANY heredoc body, quoted delimiter or not.
+    heredoc_body: std::collections::HashSet<usize>,
     /// 1-indexed line currently being scanned.
     line_no: usize,
     /// Where the outermost currently-open quote started, for the EOF fail-safe.
@@ -402,6 +428,7 @@ impl Scanner {
         if doc.quoted {
             self.quoted_heredoc.insert(self.line_no);
         }
+        self.heredoc_body.insert(self.line_no);
         marks.iter_mut().for_each(|m| *m = true);
         true
     }
@@ -494,6 +521,17 @@ impl Scanner {
 
     /// Any code context: top level, `$( )`, `${ }`, backticks, `$(( ))`.
     fn step_code(&mut self, bytes: &[u8], i: usize, marks: &mut [bool]) -> usize {
+        // `case … esac` is tracked so a pattern's `)` is not read as the close
+        // of a command substitution. Neither context is literal, so this only
+        // affects paren balance, never the mask.
+        if bytes[i] == b'c' && Self::keyword_at(bytes, i, b"case") {
+            self.stack.push(Ctx::Case);
+            return i + 4;
+        }
+        if bytes[i] == b'e' && Self::keyword_at(bytes, i, b"esac") {
+            self.pop_if(Ctx::Case);
+            return i + 4;
+        }
         match bytes[i] {
             b'\\' => i + 2,
             b'\'' => {
@@ -593,8 +631,37 @@ impl Scanner {
             }
             return i + 1;
         }
+        // Inside a `case`, this `)` terminates a pattern (`*.gz)`), it does not
+        // close a command substitution. Popping here made the scanner think it
+        // had left the `$(` and returned to the enclosing `"…"`.
+        if self.stack.last() == Some(&Ctx::Case) {
+            return i + 1;
+        }
         self.pop_if(Ctx::Paren);
         i + 1
+    }
+
+    /// Is the word at `i` a shell keyword in *command* position?
+    ///
+    /// Deliberately strict: only after a newline, `;`, `|`, `&` or `(`. That
+    /// keeps `echo case` — where `case` is an ordinary argument — from opening
+    /// a construct that never closes.
+    fn keyword_at(bytes: &[u8], i: usize, word: &[u8]) -> bool {
+        if !bytes[i..].starts_with(word) {
+            return false;
+        }
+        // Followed by a word boundary.
+        match bytes.get(i + word.len()) {
+            None => {}
+            Some(b) if b.is_ascii_whitespace() || matches!(b, b';' | b'&' | b'|') => {}
+            _ => return false,
+        }
+        // Preceded only by whitespace since a command separator.
+        let mut j = i;
+        while j > 0 && bytes[j - 1].is_ascii_whitespace() {
+            j -= 1;
+        }
+        j == 0 || matches!(bytes[j - 1], b';' | b'&' | b'|' | b'(')
     }
 
     fn pop_if(&mut self, ctx: Ctx) {
@@ -940,6 +1007,7 @@ mod tests {
             ("SC1140", sc1140::check),
             ("SC1028", sc1028::check),
             ("SC2104", sc2104::check),
+            ("SC2188", sc2188::check),
         ]
     }
 
@@ -1118,5 +1186,128 @@ mod tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_case_pattern_paren {
+    use super::*;
+
+    /// A `case` pattern's `)` must not close an enclosing `$( … )`.
+    ///
+    /// Found in infra's `ci-blackbox.sh`. The `)` of `*.gz)` popped the
+    /// `Ctx::Paren` that `$(` had pushed, so the scanner believed it was back
+    /// inside the outer `"…"`. The `'` opening the embedded awk program then
+    /// read as literal text, the awk body was never masked, and every
+    /// quote-sensitive rule fired on awk syntax (SC1007 on `ts = 1`, SC1065 on
+    /// `function f(a, b)`). `bash -n` and `shellcheck` both accept the script.
+    const CASE_IN_SUBSHELL: &str = r#"raw="$(
+    case "$f" in
+        *.gz) echo a ;;
+    esac
+    awk '
+        match($0, /"a":"[^"]+"/) {
+            ts = 1
+        }'
+)"
+"#;
+
+    #[test]
+    fn case_pattern_paren_does_not_close_command_substitution() {
+        let masked = mask_literals(CASE_IN_SUBSHELL);
+        // The awk body is a single-quoted literal, so `ts = 1` must be masked.
+        let body = masked.lines().nth(6).unwrap_or_default();
+        assert!(
+            !body.contains("ts = 1"),
+            "awk body left unmasked: {body:?}\nfull:\n{masked}"
+        );
+    }
+
+    /// The leading-paren spelling `(*.gz)` is the same pattern, balanced.
+    #[test]
+    fn leading_paren_case_pattern_also_balances() {
+        let src = "x=\"$(\n    case \"$f\" in\n        (*.gz) echo a ;;\n    esac\n    awk '\n        ts = 1\n    '\n)\"\n";
+        let masked = mask_literals(src);
+        let body = masked.lines().nth(5).unwrap_or_default();
+        assert!(!body.contains("ts = 1"), "unmasked: {body:?}");
+    }
+
+    /// MUST STILL WORK: a real `$( … )` still closes, so text after it is code
+    /// again and is NOT masked.
+    #[test]
+    fn command_substitution_still_closes_without_a_case() {
+        let src = "x=\"$(echo hi)\"\nts = 1\n";
+        let masked = mask_literals(src);
+        assert!(
+            masked.lines().nth(1).unwrap_or_default().contains("ts = 1"),
+            "code after the substitution was masked: {masked:?}"
+        );
+    }
+
+    /// MUST STILL WORK: a genuine single-quoted literal is still masked, so
+    /// quote-sensitive rules stay blind to its contents.
+    #[test]
+    fn plain_single_quoted_literal_is_still_masked() {
+        let masked = mask_literals("echo 'ts = 1'\n");
+        assert!(!masked.contains("ts = 1"), "literal not masked: {masked:?}");
+    }
+
+    /// MUST STILL WORK: `esac` ends the case, so a later `)` closes its `$(`
+    /// normally and the following line is code.
+    #[test]
+    fn paren_after_esac_still_closes_the_substitution() {
+        let src = "x=\"$(\n    case \"$f\" in\n        a) echo a ;;\n    esac\n)\"\nts = 1\n";
+        let masked = mask_literals(src);
+        assert!(
+            masked.lines().nth(5).unwrap_or_default().contains("ts = 1"),
+            "code after esac+) was masked:\n{masked}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_allowlist_is_wired {
+    use super::QUOTE_SENSITIVE_RULES;
+
+    /// Every rule named in [`QUOTE_SENSITIVE_RULES`] must actually be invoked
+    /// with the masked source in `mod_lint.rs`.
+    ///
+    /// The allowlist and that dispatch are two hand-maintained lists with
+    /// nothing tying them together — the shape of bashrs#266, where the stdlib
+    /// whitelist and the emitter dispatch disagreed and the suite asserted the
+    /// wrong thing. Adding `SC2188` to the allowlist changed nothing at the CLI
+    /// because line 315 still passed `source`, while a rule-level unit test
+    /// passed. This test is the coupling: it reads the dispatch and fails if a
+    /// listed rule is wired to the raw source.
+    #[test]
+    fn every_quote_sensitive_rule_receives_the_masked_source() {
+        let dispatch = include_str!("rules/mod_lint.rs");
+        let mut wrong = Vec::new();
+        let mut missing = Vec::new();
+
+        for code in QUOTE_SENSITIVE_RULES {
+            let module = code.to_ascii_lowercase();
+            let masked = format!("{module}::check(&masked)");
+            let raw = format!("{module}::check(source)");
+            if dispatch.contains(&masked) {
+                continue;
+            }
+            if dispatch.contains(&raw) {
+                wrong.push(*code);
+            } else {
+                missing.push(*code);
+            }
+        }
+
+        assert!(
+            wrong.is_empty(),
+            "quote-sensitive rules wired to the RAW source (they will still \
+             fire inside string literals): {wrong:?}"
+        );
+        assert!(
+            missing.is_empty(),
+            "quote-sensitive rules not dispatched from mod_lint.rs at all: \
+             {missing:?}"
+        );
     }
 }

--- a/rash/src/linter/rules/mod_lint.rs
+++ b/rash/src/linter/rules/mod_lint.rs
@@ -312,7 +312,7 @@ pub fn lint_shell(source: &str) -> LintResult {
     result.merge(sc2185::check(source));
     result.merge(sc2186::check(source));
     result.merge(sc2187::check(source));
-    result.merge(sc2188::check(source));
+    result.merge(sc2188::check(&masked));
     result.merge(sc2189::check(source));
     result.merge(sc2190::check(source));
     result.merge(sc2191::check(source));

--- a/rash/src/linter/rules/sc1007.rs
+++ b/rash/src/linter/rules/sc1007.rs
@@ -20,87 +20,102 @@
 
 use crate::linter::{Diagnostic, LintResult, Severity, Span};
 
+/// Identifiers that are commands, not assignment targets.
+const COMMAND_WORDS: &[&str] = &[
+    "echo", "printf", "return", "exit", "export", "local", "readonly",
+];
+
+/// Lines that are test or conditional context, where `=` is a comparison.
+fn is_test_context(trimmed: &str) -> bool {
+    trimmed.starts_with('[')
+        || trimmed.starts_with("if ")
+        || trimmed.starts_with("while ")
+        || trimmed.starts_with("until ")
+        || trimmed.starts_with("elif ")
+        || trimmed.starts_with("test ")
+        || trimmed.contains("[ ")
+        || trimmed.contains("[[ ")
+        || trimmed.contains("==")
+}
+
+/// The 0-indexed offset of the `=` in a spaced assignment on `trimmed`, if the
+/// line is one. `None` when the line is not an assignment worth reporting.
+fn spaced_assignment(trimmed: &str) -> Option<usize> {
+    let bytes = trimmed.as_bytes();
+
+    // A name: alphabetic or `_`, then alphanumerics and `_`.
+    let first = *bytes.first()?;
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return None;
+    }
+    let mut i = 1;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    let ident_end = i;
+
+    let has_space_before = bytes.get(i) == Some(&b' ');
+    while bytes.get(i) == Some(&b' ') {
+        i += 1;
+    }
+
+    if bytes.get(i) != Some(&b'=') || bytes.get(i + 1) == Some(&b'=') {
+        return None;
+    }
+    let eq_pos = i;
+    let has_space_after = bytes.get(i + 1) == Some(&b' ');
+
+    if !has_space_before && !has_space_after {
+        return None;
+    }
+
+    let ident = &trimmed[..ident_end];
+    if COMMAND_WORDS.contains(&ident) {
+        return None;
+    }
+    // `IFS= read -r line` is the documented idiom for reading a line verbatim:
+    // the empty value is deliberate, and the space is what separates it from
+    // the command it prefixes. shellcheck exempts `IFS` by name for the same
+    // reason and reports nothing at any severity.
+    if ident == "IFS" && !has_space_before {
+        return None;
+    }
+
+    Some(eq_pos)
+}
+
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
+    let mut continued = false;
 
-    for (line_num, line) in source.lines().enumerate() {
-        let line_num = line_num + 1;
+    for (idx, line) in source.lines().enumerate() {
+        let line_num = idx + 1;
         let trimmed = line.trim();
 
-        if trimmed.starts_with('#') || trimmed.is_empty() {
+        // A line continued with `\` carries the previous command's arguments,
+        // so `NAME=` there is an argument word, not a new assignment. Advanced
+        // before the skips below so the flag never stalls.
+        let was_continued = continued;
+        continued = line.ends_with('\\');
+
+        if was_continued || trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if is_test_context(trimmed) {
             continue;
         }
 
-        // Skip lines that are clearly test/conditional contexts
-        // [ $x = $y ], [[ $x = $y ]], test $x = $y, if/while/until
-        if trimmed.starts_with('[')
-            || trimmed.starts_with("if ")
-            || trimmed.starts_with("while ")
-            || trimmed.starts_with("until ")
-            || trimmed.starts_with("elif ")
-            || trimmed.starts_with("test ")
-            || trimmed.contains("[ ")
-            || trimmed.contains("[[ ")
-        {
+        let Some(eq_pos) = spaced_assignment(trimmed) else {
             continue;
-        }
+        };
 
-        // Skip lines containing == (comparison, not assignment)
-        if trimmed.contains("==") {
-            continue;
-        }
-
-        // Look for pattern: identifier followed by space(s) then = then space(s) then value
-        // Must start at the beginning of the (trimmed) line to be an assignment context
-        let bytes = trimmed.as_bytes();
-        let mut i = 0;
-
-        // Check for valid identifier start
-        if i < bytes.len() && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
-            i += 1;
-            // Continue through identifier chars
-            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-                i += 1;
-            }
-            let ident_end = i;
-
-            // Check for space(s) before =
-            let has_space_before = i < bytes.len() && bytes[i] == b' ';
-            while i < bytes.len() && bytes[i] == b' ' {
-                i += 1;
-            }
-
-            // Check for = (but not ==)
-            if i < bytes.len() && bytes[i] == b'=' {
-                if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
-                    continue; // This is ==, skip
-                }
-                let eq_pos = i;
-                i += 1;
-
-                // Check for space(s) after =
-                let has_space_after = i < bytes.len() && bytes[i] == b' ';
-
-                if has_space_before || has_space_after {
-                    // Skip if identifier looks like a command (common words)
-                    let ident = &trimmed[..ident_end];
-                    if matches!(
-                        ident,
-                        "echo" | "printf" | "return" | "exit" | "export" | "local" | "readonly"
-                    ) {
-                        continue;
-                    }
-
-                    let col = line.find(trimmed).unwrap_or(0) + eq_pos + 1;
-                    result.add(Diagnostic::new(
-                        "SC1007",
-                        Severity::Error,
-                        "Remove space after = if this is intended as an assignment",
-                        Span::new(line_num, col, line_num, col + 1),
-                    ));
-                }
-            }
-        }
+        let col = line.find(trimmed).unwrap_or(0) + eq_pos + 1;
+        result.add(Diagnostic::new(
+            "SC1007",
+            Severity::Error,
+            "Remove space after = if this is intended as an assignment",
+            Span::new(line_num, col, line_num, col + 1),
+        ));
     }
 
     result
@@ -171,5 +186,63 @@ mod tests {
         let script = "A = 1\nB = 2\n";
         let result = check(script);
         assert_eq!(result.diagnostics.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod tests_command_prefix_and_continuation {
+    use super::*;
+
+    /// `IFS= read -r x` is the documented idiom for reading a line without
+    /// stripping whitespace. shellcheck exempts `IFS` by name and reports
+    /// nothing at any severity; bashrs reported an ERROR.
+    #[test]
+    fn ifs_empty_assignment_is_the_read_idiom() {
+        let result = check("IFS= read -r answer || answer=\"\"\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    #[test]
+    fn ifs_prefix_on_any_command_is_fine() {
+        let result = check("IFS= cat /etc/hosts\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// A line continued with `\` is not a fresh assignment context: its words
+    /// are arguments to the command started on the previous line. shellcheck
+    /// reports nothing at any severity here.
+    #[test]
+    fn continuation_line_words_are_arguments_not_assignments() {
+        let script = "run_case \"no workspace vars\" no all \\\n    RUNNER_WORKSPACE= GITHUB_WORKSPACE= RUNNER_WORK_GLOB=\"/tmp/x\"\n";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// MUST STILL FIRE: a space *before* `=` runs the name as a command. This
+    /// is the defect the rule exists for and it stays an error.
+    #[test]
+    fn still_fires_on_space_before_equals() {
+        let result = check("FOO = bar\n");
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].code, "SC1007");
+        assert_eq!(result.diagnostics[0].severity, Severity::Error);
+    }
+
+    /// MUST STILL FIRE: a non-`IFS` empty assignment followed by a word is
+    /// still reported — only the `IFS` idiom is exempt.
+    #[test]
+    fn still_fires_on_non_ifs_empty_assignment() {
+        let result = check("FOO= bar\n");
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+    }
+
+    /// MUST STILL FIRE: the continuation exemption is one line deep. A line
+    /// after a continued line that itself does NOT continue is code again.
+    #[test]
+    fn still_fires_on_line_after_a_continuation_ends() {
+        let script = "cmd one \\\n    two\nFOO = bar\n";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].span.start_line, 3);
     }
 }

--- a/rash/src/linter/rules/sc1078.rs
+++ b/rash/src/linter/rules/sc1078.rs
@@ -42,6 +42,11 @@ pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
     let mut open: Option<OpenQuote> = None;
     let mut heredoc_end: Option<String> = None;
+    // Single-quote state spans lines exactly as double-quote state does. It
+    // used to be a local reset on every line, so the second line of a
+    // multi-line `'...'` was scanned as code and a `"` in an embedded awk or
+    // sed program opened a phantom double-quoted string that ran to EOF.
+    let mut in_single = false;
 
     for (idx, line) in source.lines().enumerate() {
         let line_num = idx + 1;
@@ -56,14 +61,15 @@ pub fn check(source: &str) -> LintResult {
 
         // A whole-line comment cannot open a string — but only when we are not
         // already inside one, where `#` is an ordinary character.
-        if open.is_none() && line.trim_start().starts_with('#') {
+        if open.is_none() && !in_single && line.trim_start().starts_with('#') {
             continue;
         }
 
-        if open.is_none() {
+        // `<<` inside a string literal is text, not a redirection.
+        if open.is_none() && !in_single {
             heredoc_end = heredoc_terminator(line);
         }
-        scan_line(line, line_num, &mut open);
+        scan_line(line, line_num, &mut open, &mut in_single);
     }
 
     if let Some(q) = open {
@@ -83,19 +89,18 @@ pub fn check(source: &str) -> LintResult {
 /// Three states, one step function each: inside `'...'` nothing is special but
 /// the closing quote; inside `"..."` a backslash escapes and only `"` closes;
 /// otherwise quotes open and an unquoted `#` ends the line.
-fn scan_line(line: &str, line_num: usize, open: &mut Option<OpenQuote>) {
+fn scan_line(line: &str, line_num: usize, open: &mut Option<OpenQuote>, in_single: &mut bool) {
     let bytes = line.as_bytes();
     let mut i = 0;
-    let mut in_single = false;
 
     while i < bytes.len() {
-        if in_single {
-            in_single = bytes[i] != b'\'';
+        if *in_single {
+            *in_single = bytes[i] != b'\'';
             i += 1;
         } else if open.is_some() {
             i = step_in_double(bytes, i, open);
         } else {
-            match step_neutral(bytes, i, line_num, open, &mut in_single) {
+            match step_neutral(bytes, i, line_num, open, in_single) {
                 Some(next) => i = next,
                 None => return, // a comment began; the rest is prose
             }
@@ -291,5 +296,79 @@ mod tests {
         // `<<<` must not swallow the rest of the file looking for a terminator.
         let script = "grep x <<< \"$var\"\necho \"unclosed";
         assert_eq!(check(script).diagnostics.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod tests_multiline_single_quote {
+    use super::*;
+
+    /// A single-quoted string that spans lines keeps its literal state across
+    /// the newline. A `"` on a continuation line is an ordinary character, so
+    /// it must not open a phantom double-quoted string.
+    ///
+    /// Found in infra's `ci-blackbox.sh`: an embedded awk program whose regex
+    /// `/"ts":"[^"]+"/` holds an odd number of `"`. `bash -n` and `shellcheck`
+    /// both accept it.
+    #[test]
+    fn multiline_single_quote_carries_across_lines() {
+        let script = "echo x | awk '\n    match($0, /\"ts\":\"[^\"]+\"/) {\n        ts = 1\n    }'\necho done\n";
+        let result = check(script);
+        assert_eq!(
+            result.diagnostics.len(),
+            0,
+            "awk body inside '...' is literal; got {:?}",
+            result.diagnostics
+        );
+    }
+
+    /// The smallest form of the same defect.
+    #[test]
+    fn double_quote_inside_multiline_single_quote_is_literal() {
+        let result = check("echo '\na\"b\n'\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// MUST STILL FIRE: carrying single-quote state must not blind the rule to
+    /// a genuinely unterminated double-quoted string.
+    #[test]
+    fn still_fires_on_genuine_unterminated_double_quote_after_single_quoted_block() {
+        let script = "echo 'literal\ntext'\necho \"unterminated\n";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].code, "SC1078");
+        assert_eq!(result.diagnostics[0].span.start_line, 3);
+    }
+
+    /// MUST STILL FIRE: an unterminated double quote opened *before* a
+    /// single-quoted line is still reported at the line where it opened.
+    #[test]
+    fn still_fires_when_unterminated_quote_precedes_single_quoted_block() {
+        let script = "echo \"oops\necho 'plain'\necho tail\n";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].code, "SC1078");
+        assert_eq!(result.diagnostics[0].span.start_line, 1);
+    }
+
+    /// MUST STILL FIRE: a multi-line double-quoted string that never closes is
+    /// still reported, even when a single-quoted region precedes it.
+    #[test]
+    fn still_fires_on_unterminated_double_quote_spanning_lines() {
+        let script = "awk 'BEGIN{print 1}'\nDIRS=\"one two\nthree four\n";
+        let result = check(script);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].span.start_line, 2);
+    }
+
+    /// `echo "oops` followed by `echo 'a"b'` is NOT an unterminated *double*
+    /// quote: the `"` in `a"b` closes it. bash reports the unmatched `'`
+    /// instead ("unexpected EOF while looking for matching `''"), and
+    /// shellcheck reports SC1073 on the single quote. SC1078's subject is the
+    /// double quote, so it correctly stays silent here.
+    #[test]
+    fn unmatched_single_quote_is_not_sc1078s_finding() {
+        let result = check("echo \"oops\necho 'a\"b'\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
     }
 }

--- a/rash/src/linter/rules/sc1128.rs
+++ b/rash/src/linter/rules/sc1128.rs
@@ -23,11 +23,22 @@ use crate::linter::{Diagnostic, LintResult, Severity, Span};
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
 
+    // A heredoc that writes a script is the ordinary way to emit one, and the
+    // emitted `#!` is line 1 of the file being written — not a misplaced
+    // shebang in the writer. Masking cannot do this job: a shebang lives in a
+    // comment, comments mask as literal text, and the rule would then miss a
+    // genuinely misplaced shebang too.
+    let heredoc = crate::linter::quoting::heredoc_body_lines(source);
+
     for (line_num, line) in source.lines().enumerate() {
         let line_num = line_num + 1; // 1-indexed
 
         // Skip the first line
         if line_num == 1 {
+            continue;
+        }
+
+        if heredoc.contains(&line_num) {
             continue;
         }
 
@@ -146,5 +157,55 @@ mod tests {
         let result = check(code);
         // The second one on line 2 should be flagged
         assert_eq!(result.diagnostics.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod tests_heredoc_body {
+    use super::*;
+
+    /// A heredoc that writes a script: the emitted shebang is line 1 of the
+    /// file being written, so it is not misplaced. `bash -n` and `shellcheck`
+    /// both accept. Found in infra's `test-disk-watch.sh`.
+    #[test]
+    fn shebang_in_a_heredoc_body_is_not_misplaced() {
+        let result = check("cat > /tmp/x <<SH\n#!/bin/sh\necho hi\nSH\necho done\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// The same for a quoted delimiter.
+    #[test]
+    fn shebang_in_a_quoted_heredoc_body_is_not_misplaced() {
+        let result = check("cat > /tmp/x <<'SH'\n#!/usr/bin/env bash\necho hi\nSH\n");
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// MUST STILL FIRE: a stray shebang in the script's own code is still
+    /// misplaced. This is the test that rejected the masking approach, which
+    /// silenced this case along with the false positive.
+    #[test]
+    fn still_fires_on_a_genuinely_misplaced_shebang() {
+        let result = check("echo hello\n#!/bin/bash\necho bye\n");
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].code, "SC1128");
+        assert_eq!(result.diagnostics[0].severity, Severity::Error);
+        assert_eq!(result.diagnostics[0].span.start_line, 2);
+    }
+
+    /// MUST STILL FIRE: the exemption stops at the terminator.
+    #[test]
+    fn still_fires_after_the_heredoc_terminator() {
+        let result = check("cat > /tmp/x <<SH\n#!/bin/sh\nSH\n#!/bin/bash\n");
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].span.start_line, 4);
+    }
+
+    /// MUST STILL FIRE: an UNTERMINATED heredoc is a guess, so its "body" must
+    /// not silence the rule — mirroring the fail-safe in `QuotedRegions`.
+    #[test]
+    fn still_fires_when_the_heredoc_never_terminates() {
+        let result = check("cat > /tmp/x <<SH\n#!/bin/bash\n");
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].span.start_line, 2);
     }
 }

--- a/rash/src/linter/rules/sc2188.rs
+++ b/rash/src/linter/rules/sc2188.rs
@@ -365,3 +365,42 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod tests_literal_content {
+    use super::*;
+
+    /// XML, HTML or a diff inside a multi-line single-quoted string is data.
+    /// Its `<` and `>` are not redirections. Reaches this rule already masked:
+    /// SC2188 is in `quoting::QUOTE_SENSITIVE_RULES`.
+    ///
+    /// Found in llama.cpp's `build-xcframework.sh`, where a plist fragment is
+    /// assigned with `local device_family='…'`. `bash -n` accepts and
+    /// shellcheck reports nothing at any severity.
+    #[test]
+    fn angle_brackets_in_a_single_quoted_literal_are_not_redirections() {
+        let masked = crate::linter::quoting::mask_literals(
+            "f(){\n    local xml='    <key>K</key>\n    <array>\n        <integer>1</integer>\n    </array>'\n}\n",
+        );
+        let result = check(&masked);
+        assert_eq!(result.diagnostics.len(), 0, "got {:?}", result.diagnostics);
+    }
+
+    /// MUST STILL FIRE: a genuine redirection with no command is still a bug.
+    #[test]
+    fn still_fires_on_a_real_bare_redirection() {
+        let masked = crate::linter::quoting::mask_literals("echo start\n> out.txt\necho done\n");
+        let result = check(&masked);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+        assert_eq!(result.diagnostics[0].code, "SC2188");
+    }
+
+    /// MUST STILL FIRE: the redirection operator itself is outside the quotes,
+    /// so a quoted *target* does not hide it.
+    #[test]
+    fn still_fires_when_only_the_target_is_quoted() {
+        let masked = crate::linter::quoting::mask_literals("echo start\n> \"$out\"\n");
+        let result = check(&masked);
+        assert_eq!(result.diagnostics.len(), 1, "got {:?}", result.diagnostics);
+    }
+}


### PR DESCRIPTION
Widening the false-positive hunt past the six rmedia tickets, to infra's 180 fleet guards and 2350 scripts across the box. Every finding fixed here is one **`bash -n` and `shellcheck` both accept**.

## Measured

| corpus | scripts | main | this branch |
|---|---|---|---|
| paiml/rmedia | 45 | 36 | **33** |
| paiml/infra guards | 180 | 211 | **179** |
| wide sweep | 2350 | 3285 | **2622** |

In the 2350-script sweep **no code increased anywhere**; only SC2188 (-623), SC1128 (-37) and SC1078 (-3) moved. Every `SEC01x`/`DET00x` count is byte-identical on both corpora:

```
DET002 60->60  SEC001 4->4  SEC003 2->2  SEC009 24->24  SEC010 9->9  SEC011 65->65
```

That invariant is the point. SEC011 found a real `rm -rf "$src_raw"` hazard in rmedia; false positives are what bury that signal.

## Root causes

**1. SC1078 — single-quote state was per-line.** Double-quote state was carried across lines, single-quote state was a local reset each line. An embedded awk program whose regex holds an odd number of `"` opened a phantom double-quoted string that ran to EOF.

```sh
echo x | awk '
    match($0, /"ts":"[^"]+"/) {   # 5 double quotes -> desync
        ts = 1
    }'
```

This also fixed a latent **false negative**: an unterminated `"` opened before a single-quoted line went unreported.

**2. `close_paren` popped `Ctx::Paren` on any `)`.** A `case` pattern closed the enclosing `$( … )`, so the scanner thought it was back in the outer `"…"`, the awk body was never masked, and every quote-sensitive rule fired on awk syntax (19 SC1007 + 8 SC1065 in infra, all from this one line):

```sh
raw="$(
    case "$f" in
        *.gz) echo a ;;      # this ) closed the $(
    esac
    awk '
        match($0, /"a":"[^"]+"/) {
            ts = 1           # SC1007 "remove space after ="
        }'
)"
```

**3. SC1007 flagged `IFS= read -r line`** — the documented idiom, which shellcheck exempts by name — and read a `\`-continued line's arguments as a fresh assignment. shellcheck reports nothing at any severity for either. (`check()` was also refactored into `is_test_context` / `spaced_assignment` to clear the complexity gate.)

**4. SC1128 reported the shebang of a script being *written* by a heredoc.** Masking was the wrong lever and the must-still-fire tests caught it: a shebang lives in a comment, comments mask as literal text, so that approach silenced genuinely misplaced shebangs too. Added `heredoc_body_lines` instead, mirroring the unterminated-heredoc fail-safe.

**5. SC2188 read `<key>` in an embedded XML/plist fragment as a redirection** — 623 of 625 in the wide sweep. It only needed the GH-226 allowlist, but **adding it there changed nothing**: `mod_lint.rs` hand-codes `source` vs `&masked` per rule. That is a second list with nothing tying it to the allowlist — the shape of #266 — and a rule-level unit test passed green while the CLI still fired. Wired it, and added the coupling test that fails when any allowlisted rule is dispatched with the raw source.

## Must still fire

Every touched rule keeps a must-still-fire test; on the built binary a script carrying one genuine defect per rule still reports all four, and the SEC011 `rm -rf` finding is intact:

```
8:1-12  [error] SC1128: The shebang must be on the first line...
6:5-6   [error] SC1007: Remove space after = ...
4:6-7   [error] SC1078: Did you forget to close this double-quoted string?
10:1-10 [error] SC2188: Redirection without command
3:1-17  [error] SEC011: Missing validation for 'src_raw' before 'rm -rf' ...
```

The four SC2188/SC1128 findings surviving the wide sweep were checked by hand and are all genuine (a real shebang on line 16 after a license header; real bare `> "$RESULTS"` truncations).

15056 lib tests pass, `cargo fmt --check` clean, no new clippy findings.

## Filed, not half-fixed

- **SC2107** flags `||` inside a `$( … )` nested in `[ … ]`: `if [ "$(_hash "$a")" = "$(_hash "$b" 2>/dev/null || true)" ]`. A safe fix needs command-substitution column data the masker does not expose. 3 in infra.
- **SC2111** reports the `function` keyword as unsupported "in sh" on a script whose shebang is `#!/usr/bin/env bash`. The rule never consults the dialect. 284 in the wide sweep; shellcheck reports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMdV9icqNz2jis3rB2PaKQ

---

## Gate: `adversarial-crux-pr`

Run against the built binary on both corpora, main vs this branch:

| corpus | scripts | FP candidates (main -> here) | SEC/DET/IDEM (main -> here) | exit |
|---|---|---|---|---|
| rmedia | 45 | 36 -> **33** | 117 -> **117** | 0 |
| infra guards | 180 | 211 -> **179** | 662 -> **662** | 0 |

`must-still-fire: 4 checked, 4 fired, 0 LOST` on both. The gate's `--self-test`
passes, so the instrument is shown capable of failing. An early run against
`machines/` returned **exit 2** (nested corpus, 0 scanned) and was treated as
NO-GO, not a pass — rerun against a flattened 180-script corpus.

## CRUX — how the field solves this, and where this diverges

All three references resolve quoting **structurally**, before any rule runs;
bashrs resolves it in `quoting.rs` and then hands rules a masked source. The
defects fixed here are all places where a rule escaped that discipline and went
back to reading physical lines.

- **shellcheck** parses to an AST, so a single-quoted awk program is one
  `T_SingleQuoted` token and a `case` pattern is a `T_CaseExpression` branch —
  neither can leak into a sibling rule. This is why it reports nothing on all
  five repros. bashrs's `QuotedRegions` is the analogous layer; fixes 1, 2 and 5
  put the rules back behind it rather than adding per-rule special cases.
- **mvdan/sh** carries quote state in the lexer (`quoteState`), so it survives a
  newline by construction — the exact property SC1078 lacked in fix 1 — and
  parses case patterns in `CaseClause`, where `)` is a pattern terminator and
  never a paren close. `Ctx::Case` in fix 2 is the shallow equivalent: enough to
  keep paren balance, without pretending to parse.
- **tree-sitter-bash** gives `heredoc_body` its own node, which is why a shebang
  inside one is not a top-level comment. `heredoc_body_lines` in fix 4 exposes
  the same fact to a rule that had no structural view at all.

**Deliberate divergences from shellcheck, in the SCxxxx namespace:**

1. **SC1007 severity is left at Error.** shellcheck reports `FOO= bar` as SC1007
   *warning* and a space *before* `=` as SC2283 *error*. bashrs folds both into
   SC1007/Error. This branch does **not** touch that: lowering severity would
   reduce the count without making the tool more accurate, which is suppression.
   Only the two genuine false positives are fixed — `IFS=`, which shellcheck
   exempts by name and reports at no severity, and the continuation line, which
   shellcheck also reports at no severity. The severity mismatch on `FOO= bar` is
   a real divergence and is left standing as a separate question.
2. **SC1078 stays silent on `echo "oops` + `echo 'a"b'`.** The `"` in `a"b`
   closes the double quote; the genuinely unmatched quote is the single one.
   `bash -n` says ``unexpected EOF while looking for matching `'`` `` and
   shellcheck reports SC1073 on the single quote. SC1078's subject is the double
   quote, so silence is correct — asserted as a test, because my first draft of
   that must-still-fire test asserted the opposite and was wrong.
