### PR TITLE
release: 7.0.0 — SCxxxx is ShellCheck's namespace, and five lexer false positives are gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "6.68.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "aprender 0.27.5",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "6.68.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -653,14 +653,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "6.68.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "6.68.0"
+version = "7.0.0"
 dependencies = [
  "bashrs",
  "criterion",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "6.68.0"
+version = "7.0.0"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ autobins = false
 path = "src/lib.rs"
 
 [dependencies]
-bashrs = { path = "rash", version = "6.67.0" }
+bashrs = { path = "rash", version = "7.0.0" }
 
 [dev-dependencies]
 provable-contracts = "0.3"
@@ -77,7 +77,7 @@ regex-automata = "0.5"
 regex-syntax = "0.9"
 
 [workspace.package]
-version = "6.68.0"
+version = "7.0.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Pragmatic AI Labs"]

--- a/bashrs-wasm/Cargo.toml
+++ b/bashrs-wasm/Cargo.toml
@@ -15,7 +15,7 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bashrs = { version = "6.67.0", path = "../rash", default-features = false, features = ["minimal"] }
+bashrs = { version = "7.0.0", path = "../rash", default-features = false, features = ["minimal"] }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rash-mcp/Cargo.toml
+++ b/rash-mcp/Cargo.toml
@@ -20,7 +20,7 @@ useless_format = "allow"  # String literals in format! are intentional for reada
 expect_used = "allow"  # Handler implementations use expect for required fields
 
 [dependencies]
-bashrs = { version = "6.67", path = "../rash" }  # Use path for workspace dev, version for publish
+bashrs = { version = "7.0.0", path = "../rash" }  # Use path for workspace dev, version for publish
 pforge-runtime = "0.1.4"
 # Use workspace dependencies for version unification (Issue #57)
 serde.workspace = true


### PR DESCRIPTION
**MAJOR**, and #277 is why: 36 bashrs-original checks move from `SCxxxx` to `BRS####`. The **emitted** code changes, so anything parsing bashrs output or keyed on a code number sees different values.

Suppression pragmas are preserved as aliases — naming `SC2081` still suppresses what is now `BRS0006` — so no `# bashrs disable` line breaks. **Baselines and dashboards keyed on emitted codes do need regenerating**, which is what the version number is for.

Shipping it now is deliberate. The collision gets more expensive every day it ships: every baseline, ratchet or `# shellcheck disable=` written against bashrs's meaning of a shellcheck code becomes wrong at reconciliation. Volume argued for fixing the noisy rules first; **irreversibility argued for the namespace, and irreversibility wins.**

## The false positives

Measured on a 45-script production corpus where `shellcheck -S error` and `bash -n` both report **0**, bashrs 6.67.0 reported **150 errors — all false**.

| PR | defect |
|---|---|
| #271 | `SC1028` flagged every paren on a line that merely *contained* a test |
| #272 | `SC1044` read `<<<'x'` as an unterminated heredoc |
| #276 | an assignment after the first separator on a line was invisible |
| #277 | the `SCxxxx` namespace collision |
| #278 | five rules read string literals, heredoc bodies and case patterns as shell code |

The remaining 10 are in #279, which is being rebased and follows.

**The SEC/DET families are unchanged — byte for byte**, same file, line, span and message. They are the reason to run this tool: `SEC011` found a real `rm -rf` through a symlink where a source and its destination resolved to one directory. The false positives were burying that signal, and removing them is the actual value here.

## Three stale version pins, fixed

`bashrs` was pinned at **6.67.0 in three places** while the workspace was 6.68.0 — `Cargo.toml`, `bashrs-wasm/Cargo.toml`, `rash-mcp/Cargo.toml`. A `path` + `version` dep resolves through the **path** locally, so a stale version is invisible in-tree and only surfaces at publish time. All three now track the release.

## Also included

#273 adds **`adversarial-crux-pr`**, the gate a lint fix passes before its PR exists: a must-still-fire fixture set plus a competitive comparison against shellcheck / mvdan-sh / tree-sitter-bash. It exists because the cheapest way to quiet a noisy rule is to make it wrong in the other direction, and nothing in an ordinary review catches that.

It has already earned its place — putting `SC1128` in the quote-sensitive allowlist **blinded it** (`mask_literals` masks comments, so a genuinely misplaced shebang would have vanished), and that was caught by the discipline rather than shipped.