### PR TITLE
release: 7.0.1 — zero false positives on the corpus, with every SEC finding intact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "aprender 0.27.5",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -653,14 +653,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bashrs",
  "criterion",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ autobins = false
 path = "src/lib.rs"
 
 [dependencies]
-bashrs = { path = "rash", version = "7.0.0" }
+bashrs = { path = "rash", version = "7.0.1" }
 
 [dev-dependencies]
 provable-contracts = "0.3"
@@ -77,7 +77,7 @@ regex-automata = "0.5"
 regex-syntax = "0.9"
 
 [workspace.package]
-version = "7.0.0"
+version = "7.0.1"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Pragmatic AI Labs"]

--- a/bashrs-wasm/Cargo.toml
+++ b/bashrs-wasm/Cargo.toml
@@ -15,7 +15,7 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bashrs = { version = "7.0.0", path = "../rash", default-features = false, features = ["minimal"] }
+bashrs = { version = "7.0.1", path = "../rash", default-features = false, features = ["minimal"] }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rash-mcp/Cargo.toml
+++ b/rash-mcp/Cargo.toml
@@ -20,7 +20,7 @@ useless_format = "allow"  # String literals in format! are intentional for reada
 expect_used = "allow"  # Handler implementations use expect for required fields
 
 [dependencies]
-bashrs = { version = "7.0.0", path = "../rash" }  # Use path for workspace dev, version for publish
+bashrs = { version = "7.0.1", path = "../rash" }  # Use path for workspace dev, version for publish
 pforge-runtime = "0.1.4"
 # Use workspace dependencies for version unification (Issue #57)
 serde.workspace = true


### PR DESCRIPTION
#279 closes the last five false-positive sources. On the 45-script corpus this campaign was measured against:

| version | error-severity findings |
|---|---|
| 6.67.0 | **150** — all false |
| 7.0.0 | 29 (26 signal + 3 residual) |
| **7.0.1** | **26** — `SEC011` ×18, `SEC010` ×4, `DET002` ×4, **zero `SCxxxx`** |

`shellcheck -S error` reports **0** over the same corpus, and `bash -n` **0**. That is the target as stated: not zero findings — **zero false findings, with the SEC01x family still firing.**

## The signal is byte-identical, verified by `diff` not by counting

```
diff before/secdet.txt after/secdet.txt  →  IDENTICAL (117 lines)
diff before/errors.txt  after/errors.txt →  IDENTICAL (26 lines)
```

Same file, same line, same span, same message. `SC2032` went **461 → 0**, as #277's retirement intends.

## The hypothesis was tested first, and did not hold

`linter::quoting` already carried quoting and heredoc state correctly. There were **five independent causes**, the largest being that `SC1078` kept its *own weaker scanner* — `in_single` was a local of `scan_line`, reset at every newline. Testing the hypothesis before writing patches is what surfaced that.

## Two resolutions that would otherwise have shipped a false negative

- **#278 asserted `echo "oops\necho 'a"b'` yields no diagnostic.** Measured: `bash -n` rejects the file, and **shellcheck itself emits `SC1078` on it**. Silence there is a false negative, so the test was **inverted** rather than satisfied.
- **#276 pinned `for((i=0;i<3;i++))` as a must-fire for `SC1035`.** `bash -n` accepts it and it runs. Also inverted. The merged rule is **stronger than either side**: it keeps #276's `then&` catch via a new `TERMINATOR_KEYWORDS` split, and drops four metacharacters with measured valid counterexamples.

## Verification

- **Gate** (`.claude/skills/adversarial-crux-pr`, added in #273): **exit 0** — 4 of 4 must-still-fire rules still firing
- **8 mutation proofs**, each shown capable of red on revert
- **15,201** lib tests + **16,592** test-binary tests, **0 failed**
- `cargo fmt --check` clean; no new clippy warnings

## Known, and deliberately not fixed here

`then(echo hi)` and `while(true)` are accepted by `bash -n` and still report `SC1035`. It predates both #276 and #279 and deserves its own ticket rather than being folded into a conflict resolution.

Also carries the three `bashrs` version pins (`Cargo.toml`, `bashrs-wasm`, `rash-mcp`), which resolve through `path` locally and only surface at publish.