### PR TITLE
tickets: PMAT-244 — SC2105 false positive on single-line loops

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2049,3 +2049,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-244
+  github_issue: null
+  item_type: task
+  title: 'lint SC2105 false positive: break inside a single-line for/while loop reported as ''only valid in loops'''
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:21:38Z
+  updated: 2026-09-02T16:21:38Z
+  spec: null
+  acceptance_criteria:
+  - 'bashrs 7.0.1 `bashrs lint` reports SC2105 for a break that IS inside a loop when the whole loop is written on one line. Minimal repro, four variants: (v1) ''for m in a b; do [[ $m == b ]] && { x=1; break; }; done'' -> SC2105 error; (v2) ''for m in a b; do if [[ $m == b ]]; then x=1; break; fi; done'' -> SC2105 error (two errors); (v3) same as v2 split across lines -> clean; (v4) same as v1 split across lines -> clean. So the checker''s loop-nesting context is line-scoped, not AST-scoped. Found 2026-09-02 linting ~/.claude/hooks/xpile-stop-guard.sh (infra PMAT-225); worked around by reflowing the loop, which is exactly the routing-around the dogfood doctrine forbids — the fix belongs here, with v1..v4 as fixtures (per form VARIANT, not per form).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null


### PR DESCRIPTION
Roadmap-only: files PMAT-244. `bashrs lint` 7.0.1 flags SC2105 on a `break` that is inside a `for`/`while` when the loop is written on one line; the identical loop split across lines lints clean, so the checker's nesting context is line-scoped rather than AST-scoped. Repro variants v1–v4 are recorded in the ticket, one per form variant, so the fix can carry them as fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbGzNx3EU7LKRq1DyJbo5W
