### PR TITLE
docs(audits): PMAT-245 receipt — DONE, v7.0.2 released on GitHub and crates.io

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.39.0",
-  "created_at": "2026-09-09T18:07:18.807382535Z",
+  "created_at": "2026-09-09T20:53:40.933036181Z",
   "git_context": null,
   "files": {
     "./bashrs-oracle/src/categories.rs": {

--- a/docs/audits/impl-PMAT-245-receipt.md
+++ b/docs/audits/impl-PMAT-245-receipt.md
@@ -143,3 +143,26 @@
 | not done | not pushed to the PR branch: attempt 3 (`gh run rerun --failed`, test job alone, started 17:49 UTC, deadline 18:49 UTC) is live. If it passes, PR #285 merges as-is and the side branch becomes a follow-up PR; if it times out, the PR branch fast-forwards onto the side branch and CI re-runs with the fix. |
 | jidoka | row appended to `.pmat/jidoka.jsonl` (5 whys). PMAT-247 to file: lib-test job 48–55 min vs fixed 60-min limit; and CI runs `--workspace --lib`, so `rash/tests/corpus_registry_contract_tests.rs` executes only via `make test-contracts`. |
 | k | turn count continues under the K=120 declared in session 2 |
+
+## DONE — release shipped (session 3, 2026-09-09 20:48 UTC)
+
+| step | evidence |
+|---|---|
+| gate on PR head `2d44552617` | run 34391566581: `ci / test` success at 57 min 06 s (15,206 tests, 68 skipped); coverage success; top-level `gate` success 19:53:17 UTC. Attempts on the previous head `b4c62de3bd` timed out 3× (run 34368312280: 10,791 / 15,201 / 15,201 of 15,202) — root cause and countermeasure in the session-3 section above. |
+| merge | PR #285 merged 19:53:47 UTC as merge commit `f700599b14` (merge commit, not squash: the receipt, CHANGELOG and jidoka rows cite the individual measured commits by SHA). Issue #284 auto-closed. |
+| gate on the merge commit | run 34397787169 on `f700599b14`: test success at 51 min, coverage success, `gate` success 20:45:12 UTC. |
+| tag | annotated `v7.0.2` on `f700599b14`, message = CHANGELOG 7.0.2 entry + Cargo.lock fix + corpus-registry contract; pushed 20:46 UTC. |
+| GitHub Release | release.yml run 34403020285 success; https://github.com/paiml/bashrs/releases/tag/v7.0.2 published 20:47:31 UTC by github-actions[bot] (tag == `cargo metadata` version 7.0.2; `cargo package --locked` verified in CI). |
+| crates.io | `cargo publish -p bashrs --locked` from the tag checkout: 1975 files, 3.7 MiB compressed, "Published bashrs v7.0.2 at registry crates-io" 20:47:26 UTC. crates.io API: `max_version=7.0.2 newest=7.0.2 updated=2026-09-09T20:47:23Z`. |
+| install | `cargo install bashrs --version 7.0.2 --locked --root <tmp>` from the registry → `bashrs 7.0.2`. Installed-binary `bashrs corpus summary` result recorded below when it finishes. |
+| corpus bar | CHANGELOG 7.0.2 records 17,942 entries, 84.4/100 (B), measured on the 7.0.2 release binary (session 2); the release commits after that measurement change tests, docs and one pure refactor of a non-scoring path (`training_config`), not transpiler output. |
+| follow-up | PMAT-247 filed and PR #288 opened (`PMAT-247-corpus-test-cost`, 3 commits, contract `corpus-derived-generators-v1`): the remaining ten full-corpus unit tests (567–2,243 s each) drop to 11 s for their four modules. The 60-minute job timeout itself is paiml/.github's, an org decision. |
+| ticket | `pmat work complete PMAT-245` refused at first: LadderShortfall — the work contract claimed L3, evidence supports L1 (falsification tests executed; kani harnesses are specified, not run). Claim lowered to what the evidence supports; completion result recorded in the commit that carries this section. |
+
+Estimates: `docs/audits/impl-estimates.jsonl` rows filled — `all` actual=194 turns (tool calls across sessions 1–3), `resume-release` actual=98 turns (session 3 alone). K was re-declared 40→120 at k=60; it was exceeded at k=121 inside the CI-timeout loop (three 60-minute waits polled at 1-minute intervals, then two contract-first fixes). Not re-declared mid-loop; recorded here as an overrun whose cause is CI capacity, not scope.
+
+[status] ticket=PMAT-245 phase=5/5 global=194/120(K=120) k_measured=194 sub=1/1 basis=first-run[U]
+         mode=direct trigger=- route=self w=1 q=absent gate=PASS slots=0/3 denied=0
+         red=- filed=PMAT-246,PMAT-247 blocker=- next=none — v7.0.2 is on GitHub and crates.io; PR #288 (PMAT-247) awaits its gate and review
+
+**Verdict: DONE.** v7.0.2 is released on both channels, the gate was green on the merge commit, and every claim above was re-run or read from the run/API that produced it.

--- a/docs/audits/impl-PMAT-245-receipt.md
+++ b/docs/audits/impl-PMAT-245-receipt.md
@@ -154,7 +154,7 @@
 | tag | annotated `v7.0.2` on `f700599b14`, message = CHANGELOG 7.0.2 entry + Cargo.lock fix + corpus-registry contract; pushed 20:46 UTC. |
 | GitHub Release | release.yml run 34403020285 success; https://github.com/paiml/bashrs/releases/tag/v7.0.2 published 20:47:31 UTC by github-actions[bot] (tag == `cargo metadata` version 7.0.2; `cargo package --locked` verified in CI). |
 | crates.io | `cargo publish -p bashrs --locked` from the tag checkout: 1975 files, 3.7 MiB compressed, "Published bashrs v7.0.2 at registry crates-io" 20:47:26 UTC. crates.io API: `max_version=7.0.2 newest=7.0.2 updated=2026-09-09T20:47:23Z`. |
-| install | `cargo install bashrs --version 7.0.2 --locked --root <tmp>` from the registry → `bashrs 7.0.2`. Installed-binary `bashrs corpus summary` result recorded below when it finishes. |
+| install | `cargo install bashrs --version 7.0.2 --locked --root <tmp>` from the registry → `bashrs 7.0.2`. The installed binary's `bashrs corpus summary`: **17942 entries, 84.4/100 B, 333 failure(s)** — identical to the CHANGELOG; the published artifact meets the >= 17,942 bar itself. |
 | corpus bar | CHANGELOG 7.0.2 records 17,942 entries, 84.4/100 (B), measured on the 7.0.2 release binary (session 2); the release commits after that measurement change tests, docs and one pure refactor of a non-scoring path (`training_config`), not transpiler output. |
 | follow-up | PMAT-247 filed and PR #288 opened (`PMAT-247-corpus-test-cost`, 3 commits, contract `corpus-derived-generators-v1`): the remaining ten full-corpus unit tests (567–2,243 s each) drop to 11 s for their four modules. The 60-minute job timeout itself is paiml/.github's, an org decision. |
 | ticket | `pmat work complete PMAT-245` refused at first: LadderShortfall — the work contract claimed L3, evidence supports L1 (falsification tests executed; kani harnesses are specified, not run). Claim lowered to what the evidence supports; completion result recorded in the commit that carries this section. |
@@ -166,3 +166,18 @@ Estimates: `docs/audits/impl-estimates.jsonl` rows filled — `all` actual=194 t
          red=- filed=PMAT-246,PMAT-247 blocker=- next=none — v7.0.2 is on GitHub and crates.io; PR #288 (PMAT-247) awaits its gate and review
 
 **Verdict: DONE.** v7.0.2 is released on both channels, the gate was green on the merge commit, and every claim above was re-run or read from the run/API that produced it.
+
+### pmat work complete — left `inprogress`, not overridden
+
+`pmat work complete PMAT-245` (after lowering the work contract's claim to L1) reports 6 falsifications and offers `--override-claims --ticket`. I did not use it. The work contract at `.pmat-work/PMAT-245/contract.json` (untracked, local) carries a baseline of commit `c3e08ec8b2` from **2026-04-07**, so its "still exists / no new" checks compare against a tree five months old:
+
+| check | finding | attributable to PMAT-245? |
+|---|---|---|
+| All baseline files still exist | `rash/tests/falsification_probar_testing_tests_falsification.rs` missing | no — deleted 2026-08-18 in `391c25713a` ("145 integration targets did not compile, 37 dead") |
+| No new dead code introduced | dead code in "changed file" `rash/src/linter/mod.rs` | no — PR #285 does not touch that file (`git diff --stat 443bd7ba78..f700599b14 -- rash/src/linter/mod.rs` is empty: 0 lines) |
+| No function exceeds complexity 20 | repo-wide | no — pre-existing; the pre-commit hook enforces 30/25 |
+| No file exceeds 500 lines | 1,822 files, including `.claude/worktrees/**` | no — repo-wide, pre-existing |
+| All match arm variants have test coverage | 204 untested variants, e.g. `rash/src/ast/visitor_tests.rs` | no — repo-wide, pre-existing |
+| Total / per-file coverage | NOT MEASURED (no lcov in this session) | n/a |
+
+Everything the user asked for is shipped; closing the pmat ticket needs either a recorded override (`--override-claims` with a ticket) or a refreshed baseline plus repo-wide fixes. That is the user's call — noted, not laundered.

--- a/docs/audits/impl-estimates.jsonl
+++ b/docs/audits/impl-estimates.jsonl
@@ -1,2 +1,2 @@
-{"repo":"bashrs","ticket":"PMAT-245","phase":"all","mode":"direct+quorum","est":4,"actual":null,"basis":"first-run[U]"}
-{"repo":"bashrs","ticket":"PMAT-245","phase":"resume-release","mode":"direct+quorum","est":5,"actual":null,"basis":"first-run[U]"}
+{"repo":"bashrs","ticket":"PMAT-245","phase":"all","mode":"direct+quorum","est":4,"actual":194,"unit":"turn","basis":"first-run[U]"}
+{"repo":"bashrs","ticket":"PMAT-245","phase":"resume-release","mode":"direct+quorum","est":5,"actual":98,"unit":"turn","basis":"first-run[U]"}


### PR DESCRIPTION
Closing paperwork for PMAT-245 / #284 (the P0 from `docs/audit/quality-report09-2026.md`). No code.

- Receipt promoted to **DONE** with the evidence chain: gate green on the PR head and on merge commit `f700599b14`, tag `v7.0.2`, GitHub Release (release.yml run 34403020285), `cargo publish -p bashrs --locked` → crates.io `max_version=7.0.2`, `cargo install bashrs --version 7.0.2` → `bashrs 7.0.2`, and the installed binary's `bashrs corpus summary`: 17942 entries, 84.4/100 B — identical to the CHANGELOG.
- Session-3 findings: three CI timeouts at the fixed 60-minute limit, root cause (full-corpus unit tests), countermeasure inside #285, and PMAT-247 / #288 for the rest.
- `docs/audits/impl-estimates.jsonl`: `actual` filled (194 turns total, 98 in session 3); K=120 overrun recorded, cause CI capacity.
- `pmat work complete PMAT-245` left `inprogress` and **not** overridden: its six falsifications compare against a 2026-04-07 baseline and repo-wide pre-existing gates; none is attributable to this ticket (table in the receipt). Your call whether to record an override or refresh the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UrgGYodiz41sH6JGETKmu