### PR TITLE
docs(release): close PMAT-257, v7.2.0 shipped and verified

### DIFF
--- a/docs/audits/impl-PMAT-257-receipt.md
+++ b/docs/audits/impl-PMAT-257-receipt.md
@@ -101,3 +101,18 @@ DONE for the ten defects, the pv gate and the corpus. PARTIAL(escalate) for the 
 | 34 files | **95.01%** | 34 | 363 |
 
 Twenty-one worker dispatches over seven waves; every one stopped at its 40-turn limit, and the orchestrator committed what they left staged after re-running it. Four tests that ran the real corpus (143 to 148s each) were removed after timing; one dispatcher file's 19 tests (312s) were discarded. The functions gate refused two files for legacy complexity (corpus_b2_commands, cognitive 41) and one test helper (fixed).
+
+## Released
+
+v7.2.0 shipped 2026-09-11 from merge commit f322f2a39f, required check `gate` green on it.
+
+| channel | verified |
+|---|---|
+| crates.io sparse index | `bashrs` and `bashrs-oracle` both at 7.2.0 |
+| GitHub release | v7.2.0 present, release workflow succeeded |
+| install | `cargo install bashrs --version 7.2.0` replaced 7.1.0, `bashrs --version` reports 7.2.0 |
+| binary check | MAKE010 fires once on a masked `cp`, matching the re-specified contract |
+
+Release gate, measured end to end before the tag: workspace tests pass, coverage 95.00 percent lines (gate fails under 95), `pv lint contracts` PASS with gate 4 at 73/73, corpus 18,453 entries at 99.4/100 (A+) under bwrap, book builds and its examples pass.
+
+Two gate defects were found by running the release gate at all, and both are fixed rather than worked around: three MAKE010 tests asserted a contract PMAT-251 had deliberately replaced (#317, closed with the measurements), and the corpus regression gate read its convergence log from the process working directory, so a unit test passed alone and failed in the workspace run.

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -15,14 +15,15 @@ Goal: the five v7.1.0 issues fixed and measured against their own reproducers, t
 
 Issues on the GitHub milestone `v7.1.0`: #293, #294, #295, #265, #232.
 
-## v7.2.0
+## v7.2.0 (released 2026-09-11)
 
 | entry | what |
 |---|---|
 | PMAT-253 | forjar parity, the phases not shipped in v7.1.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b (`docs/specifications/pr-dogfood-parity-forjar.md`), with §4 settled by quorum |
 | PMAT-243 | COV-MEASURE: measure line coverage, name the top ten gaps, record both |
 | PMAT-246 | work contracts regenerated so pv validates all 103; the CB-1305 half is upstream (paiml-mcp-agent-toolkit#1306) |
-| PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it |
+| PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it (make corpus-score sandboxes the release run; the runner itself is v7.3.0) |
+| PMAT-257 | the release itself: ten defects, pv gate 4 green, coverage 95.01 percent, the Pareto gates, the book |
 
 ## Unscheduled (blocked)
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2310,7 +2310,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'v7.2.0: pv-enforced release — triage every open issue, the 7.1.0 lint regressions, deps, corpus growth, PMAT-243/253/256'
-  status: planned
+  status: completed
   priority: critical
   assigned_to: null
   created: 2026-09-11T06:34:09Z
@@ -2323,4 +2323,4 @@ roadmap:
   labels:
   - kind:code
   - release:v7.2.0
-  notes: null
+  notes: 'Shipped as v7.2.0 on 2026-09-11: ten dogfooding defects, pv gate 4 from 16 missing refs to zero, library coverage 91.72 to 95.01 percent behind make coverage-gate, a Pareto PR gate (111s against 944s), corpus 18,453 entries at 99.4/100, and the book updated. Receipt: docs/audits/impl-PMAT-257-receipt.md'


### PR DESCRIPTION
v7.2.0 is published. This closes the ticket and records the verification.

| channel | verified |
|---|---|
| crates.io sparse index | `bashrs` and `bashrs-oracle` both at 7.2.0 |
| GitHub release | v7.2.0 present, release workflow succeeded |
| install | `cargo install bashrs --version 7.2.0` replaced 7.1.0 |
| binary | MAKE010 fires once on a masked `cp`, matching the re-specified contract |

Release gate before the tag: workspace tests pass, **coverage 95.00 percent**, `pv lint contracts` PASS with gate 4 at 73 of 73, corpus **18,453 entries at 99.4/100 (A+)** under bwrap, book builds and its examples pass. The required `gate` check was green on merge commit f322f2a39f before the tag was cut.

Still open on v7.2.0 and carried forward: PMAT-253's remaining phases, PMAT-256 (the runner's own sandbox; `make corpus-score` sandboxes the release run today), and issues #303, #316, #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)