### PR TITLE
fix(corpus): the convergence-log path the release gate caught

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
  "aprender 0.27.8",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -756,14 +756,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "bashrs",
  "criterion",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "aprender 0.27.8",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -756,14 +756,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "bashrs",
  "criterion",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/docs/audits/impl-PMAT-259-receipt.md
+++ b/docs/audits/impl-PMAT-259-receipt.md
@@ -4,7 +4,7 @@
 
 `test_cov_corpus_converged_no_log` asserts that `corpus_converged` errors when there is no convergence log. The function read `.quality/convergence.log` from the process working directory, so the assertion held only in a checkout that happened not to carry that file. This one carries it, dated 2026-02-09, and the test failed in the v7.3.0 release gate.
 
-`corpus_converged_with_log` takes the path; `corpus_converged` passes the default. No caller changes and no behaviour changes. The test points at a `tempfile::TempDir`.
+`corpus_converged_with_log` takes the path; `corpus_converged` keeps its signature and passes the default. Quorum round 1 read the original ticket title as promising that `corpus_converged` itself would take a path, which would change the CLI entry point for no gain; the title now says what the diff does. No caller changes and no behaviour changes. The test points at a `tempfile::TempDir`.
 
 ## Why it is its own ticket
 

--- a/docs/audits/impl-PMAT-259-receipt.md
+++ b/docs/audits/impl-PMAT-259-receipt.md
@@ -1,0 +1,23 @@
+# PMAT-259 receipt — the convergence-log path
+
+## What and why
+
+`test_cov_corpus_converged_no_log` asserts that `corpus_converged` errors when there is no convergence log. The function read `.quality/convergence.log` from the process working directory, so the assertion held only in a checkout that happened not to carry that file. This one carries it, dated 2026-02-09, and the test failed in the v7.3.0 release gate.
+
+`corpus_converged_with_log` takes the path; `corpus_converged` passes the default. No caller changes and no behaviour changes. The test points at a `tempfile::TempDir`.
+
+## Why it is its own ticket
+
+It was found while gating PMAT-258 and could have ridden along, but a quorum reviews a diff against its ticket's stated intent: three lanes refused the follow-up precisely because its one commit does not implement the release ticket they were shown. One ticket per diff is the rule that makes the review meaningful.
+
+## Verification
+
+| check | result |
+|---|---|
+| `cargo test -p bashrs --lib` | 15,672 passed, 0 failed |
+| the test under change | passes, and now fails for the right reason if the split is reverted |
+| pre-commit gates | format, complexity, clippy stage, SATD all green |
+
+## Related
+
+The corpus gate's regression check had the same shape earlier in this release and was fixed the same way. Both were found by the full release gate rather than the PR gate, which is the division of labour the two gates exist for.

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -34,7 +34,7 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 | PMAT-258 | the release: #303, #316, #318, deps, comply, corpus growth, the book |
 | PMAT-253 | forjar parity, the phases not shipped in v7.2.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b |
 | PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it |
-| PMAT-259 | corpus_converged reads its convergence log from the caller, so a test cannot depend on the checkout |
+| PMAT-259 | corpus_converged gains a _with_log twin, so a test does not depend on the checkout |
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
 

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -34,6 +34,7 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 | PMAT-258 | the release: #303, #316, #318, deps, comply, corpus growth, the book |
 | PMAT-253 | forjar parity, the phases not shipped in v7.2.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b |
 | PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it |
+| PMAT-259 | corpus_converged reads its convergence log from the caller, so a test cannot depend on the checkout |
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2345,7 +2345,7 @@ roadmap:
 - id: PMAT-259
   github_issue: null
   item_type: task
-  title: corpus_converged reads its convergence log from the caller, not the working directory
+  title: 'corpus_converged gains a _with_log twin, so a test does not depend on the checkout'
   status: planned
   priority: high
   assigned_to: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2342,3 +2342,21 @@ roadmap:
   - kind:code
   - release:v7.3.0
   notes: null
+- id: PMAT-259
+  github_issue: null
+  item_type: task
+  title: corpus_converged reads its convergence log from the caller, not the working directory
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T21:01:12Z
+  updated: 2026-09-11T21:01:12Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - release:v7.3.0
+  notes: null

--- a/rash/src/cli/command_tests_installer_cov_tests_cov.rs
+++ b/rash/src/cli/command_tests_installer_cov_tests_cov.rs
@@ -344,9 +344,17 @@ mod corpus_core_smoke {
 
     #[test]
     fn test_cov_corpus_converged_no_log() {
-        // No convergence log → should fail (fast: no corpus load)
-        let res = super::super::corpus_ops_commands::corpus_converged(99.0, 0.5, 3);
-        assert!(res.is_err());
+        // PMAT-258: point it at a directory that has no log, rather than at
+        // whatever `.quality/convergence.log` the repository happens to carry.
+        // This assertion used to pass only because the checkout had no log yet.
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let res = super::super::corpus_ops_commands::corpus_converged_with_log(
+            99.0,
+            0.5,
+            3,
+            &dir.path().join("convergence.log"),
+        );
+        assert!(res.is_err(), "a missing convergence log is an error");
     }
 
     #[test]

--- a/rash/src/cli/command_tests_installer_cov_tests_cov.rs
+++ b/rash/src/cli/command_tests_installer_cov_tests_cov.rs
@@ -344,7 +344,7 @@ mod corpus_core_smoke {
 
     #[test]
     fn test_cov_corpus_converged_no_log() {
-        // PMAT-258: point it at a directory that has no log, rather than at
+        // PMAT-259: point it at a directory that has no log, rather than at
         // whatever `.quality/convergence.log` the repository happens to carry.
         // This assertion used to pass only because the checkout had no log yet.
         let dir = tempfile::TempDir::new().expect("temp dir");

--- a/rash/src/cli/corpus_ops_commands.rs
+++ b/rash/src/cli/corpus_ops_commands.rs
@@ -72,7 +72,7 @@ pub(crate) fn corpus_converged(min_rate: f64, max_delta: f64, min_stable: usize)
     )
 }
 
-/// PMAT-258: body of `corpus_converged`, split so the convergence log comes
+/// PMAT-259: body of `corpus_converged`, split so the convergence log comes
 /// from the caller. Without this the verdict depends on whichever log happens
 /// to sit in the process's working directory, and a test asserting "no log"
 /// passes or fails according to the repository's own state rather than the

--- a/rash/src/cli/corpus_ops_commands.rs
+++ b/rash/src/cli/corpus_ops_commands.rs
@@ -64,11 +64,29 @@ pub(crate) fn names_similar(a: &str, b: &str) -> bool {
 /// Check convergence criteria from spec §5.2.
 /// Returns exit code 0 if converged, 1 if not.
 pub(crate) fn corpus_converged(min_rate: f64, max_delta: f64, min_stable: usize) -> Result<()> {
+    corpus_converged_with_log(
+        min_rate,
+        max_delta,
+        min_stable,
+        &PathBuf::from(".quality/convergence.log"),
+    )
+}
+
+/// PMAT-258: body of `corpus_converged`, split so the convergence log comes
+/// from the caller. Without this the verdict depends on whichever log happens
+/// to sit in the process's working directory, and a test asserting "no log"
+/// passes or fails according to the repository's own state rather than the
+/// code's behaviour.
+pub(crate) fn corpus_converged_with_log(
+    min_rate: f64,
+    max_delta: f64,
+    min_stable: usize,
+    log_path: &std::path::Path,
+) -> Result<()> {
     use crate::cli::color::*;
     use crate::corpus::runner::CorpusRunner;
 
-    let log_path = PathBuf::from(".quality/convergence.log");
-    let entries = CorpusRunner::load_convergence_log(&log_path)
+    let entries = CorpusRunner::load_convergence_log(log_path)
         .map_err(|e| Error::Internal(format!("Failed to read convergence log: {e}")))?;
 
     if entries.len() < min_stable {


### PR DESCRIPTION
The v7.3.0 release gate found a test whose verdict depends on the repository's own state.

`test_cov_corpus_converged_no_log` asserts that `corpus_converged` errors when there is no convergence log, while the function read `.quality/convergence.log` from the process working directory. A checkout carrying that file turns the assertion on its head, and this one carries it.

`corpus_converged_with_log` takes the path; `corpus_converged` passes the default, so no caller and no behaviour changes. The test points at a temp directory.

This is the second path of its shape this release: the corpus gate's regression check had the same problem and was fixed the same way. Both were found by running the full release gate rather than the PR gate, which is what the pre-release gate is for.

Measured here: `cargo test -p bashrs --lib` 15,672 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)