### PR TITLE
fix(release): regenerate Cargo.lock for 7.3.0 (PMAT-260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashrs"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
  "aprender 0.27.8",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-oracle"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
  "aprender 0.26.3",
@@ -756,14 +756,14 @@ dependencies = [
 
 [[package]]
 name = "bashrs-runtime"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "bashrs-specs"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "bashrs",
  "criterion",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "bashrs-wasm"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "bashrs",
  "jugar-probar",

--- a/docs/audits/impl-PMAT-260-receipt.md
+++ b/docs/audits/impl-PMAT-260-receipt.md
@@ -1,0 +1,34 @@
+# PMAT-260 receipt — the 7.3.0 lockfile
+
+## What was wrong
+
+The v7.3.0 release bumped the workspace manifest to `7.3.0` and did not regenerate `Cargo.lock`, which still named `7.2.0` for the five workspace members. Measured on `main` before this change:
+
+```
+$ cargo metadata --locked --format-version 1
+error: cannot update the lock file … because --locked was passed to prevent this
+$ cargo check --locked -p bashrs --lib
+error: (the same)
+```
+
+`scripts/publish-from-tag.sh` publishes with `--locked`, so v7.3.0 could not have been published from `main` as it stood. This is a release blocker, not housekeeping.
+
+## How it was found
+
+A quorum lane reviewing an unrelated pull request asked why that diff carried a lock bump. The bump was indeed out of scope there and was removed; the question is what exposed the blocker.
+
+## The change
+
+`cargo metadata` regenerates the file. Five workspace members move 7.2.0 to 7.3.0: `bashrs`, `bashrs-oracle`, `bashrs-runtime`, `bashrs-specs`, `bashrs-wasm`. No dependency version changes.
+
+## Verification
+
+| check | before | after |
+|---|---|---|
+| `cargo metadata --locked` | exit 101 | exit 0 |
+| workspace members at 7.3.0 in the lock | 0 of 5 | 5 of 5 |
+| dependency versions changed | — | none |
+
+## Why it is its own ticket
+
+Two quorum rounds refused a diff that was judged against the release ticket it was cut from: a review compares a diff with its ticket's stated intent, so a one-file fix needs a one-file ticket. This is the third time that rule bit in this release, and each time the reviewer was right.

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -35,6 +35,7 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 | PMAT-253 | forjar parity, the phases not shipped in v7.2.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b |
 | PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it |
 | PMAT-259 | corpus_converged gains a _with_log twin, so a test does not depend on the checkout |
+| PMAT-260 | regenerate Cargo.lock for 7.3.0, without which --locked builds and the publish script fail |
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2360,3 +2360,21 @@ roadmap:
   - kind:code
   - release:v7.3.0
   notes: null
+- id: PMAT-260
+  github_issue: null
+  item_type: task
+  title: regenerate Cargo.lock for 7.3.0 so --locked builds and the publish script work
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-09-11T23:32:17Z
+  updated: 2026-09-11T23:32:17Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - release:v7.3.0
+  notes: null


### PR DESCRIPTION
A release blocker, found by a quorum lane asking why an unrelated pull request carried a lock bump.

The v7.3.0 release bumped the workspace manifest but not the lockfile, so `main` carries `7.3.0` in `Cargo.toml` and `7.2.0` in `Cargo.lock`.

Measured on `main` before this change:

```
$ cargo metadata --locked --format-version 1
error: cannot update the lock file /home/noah/src/bashrs/Cargo.lock because --locked was passed to prevent this
```

`cargo check --locked` fails the same way, and `scripts/publish-from-tag.sh` publishes with `--locked`. So v7.3.0 could not have been published from `main` as it stood. After regenerating: `cargo metadata --locked` exits 0.

Five packages move from 7.2.0 to 7.3.0: `bashrs`, `bashrs-oracle`, `bashrs-runtime`, `bashrs-specs`, `bashrs-wasm`. No dependency versions change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)