### PR TITLE
test(cov): cover the convergence, diff and report handlers (PMAT-261)

### DIFF
--- a/docs/audits/impl-PMAT-261-receipt.md
+++ b/docs/audits/impl-PMAT-261-receipt.md
@@ -1,0 +1,24 @@
+# PMAT-261 receipt — coverage back above the gate
+
+## Why
+
+The v7.3.0 release gate measured **94.98 percent** line coverage, under the repository's 95 percent gate. PMAT-259 and PMAT-260 had added lines that no test reached: the `corpus_converged_with_log` split, and the diff and report twins beside it.
+
+## What
+
+Fifteen tests across two files, all through the `_with` twins so none of them reads the repository's own `.quality/convergence.log` or runs the full corpus:
+
+- the convergence check from both sides — missing log, too few iterations, all checks passing, rate under the bar, delta over it, a regression between iterations — plus the two pure helpers beside it;
+- the diff handler in human and json form, with an explicit iteration pair and the unknown-iteration error;
+- the report handler written to a path and to stdout, and the date helper.
+
+Every fixture is a log written into a `TempDir` and a one-entry registry.
+
+## Verification
+
+| check | before | after |
+|---|---|---|
+| line coverage | 94.98% | **95.06%** |
+| `cargo llvm-cov --lib -p bashrs --fail-under-lines 95` | fails | exit 0 |
+| function coverage | 95.58% | 95.61% |
+| new tests | — | 15, running in 0.59s |

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -36,6 +36,7 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 | PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it |
 | PMAT-259 | corpus_converged gains a _with_log twin, so a test does not depend on the checkout |
 | PMAT-260 | regenerate Cargo.lock for 7.3.0, without which --locked builds and the publish script fail |
+| PMAT-261 | cover the convergence check, restoring coverage above the 95 percent gate |
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2378,3 +2378,21 @@ roadmap:
   - kind:code
   - release:v7.3.0
   notes: null
+- id: PMAT-261
+  github_issue: null
+  item_type: task
+  title: cover the convergence check, restoring the 95 percent coverage gate
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-12T00:24:58Z
+  updated: 2026-09-12T00:24:58Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - release:v7.3.0
+  notes: null

--- a/rash/src/cli/corpus_diff_commands.rs
+++ b/rash/src/cli/corpus_diff_commands.rs
@@ -250,3 +250,125 @@ pub(crate) fn chrono_free_date() -> String {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string())
 }
+
+// PMAT-261: coverage for the diff and report handlers, through their `_with`
+// twins so no test reads the repository's own convergence log or runs the
+// full corpus: a three-entry registry and a TempDir log are enough.
+#[cfg(test)]
+mod pmat261_cov_tests {
+    use super::*;
+    use crate::corpus::registry::{CorpusEntry, CorpusFormat, CorpusRegistry, CorpusTier};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn line(iteration: u32, rate: f64, delta: f64, passed: usize, total: usize) -> String {
+        format!(
+            r#"{{"iteration":{iteration},"date":"2026-09-12","total":{total},"passed":{passed},"failed":{},"rate":{rate},"delta":{delta},"notes":"fixture"}}"#,
+            total - passed
+        )
+    }
+
+    fn log_with(dir: &TempDir, lines: &[String]) -> std::path::PathBuf {
+        let p = dir.path().join("convergence.log");
+        let mut f = std::fs::File::create(&p).expect("log created");
+        for l in lines {
+            writeln!(f, "{l}").expect("line written");
+        }
+        p
+    }
+
+    fn tiny_registry() -> CorpusRegistry {
+        let mut r = CorpusRegistry::new();
+        r.add(CorpusEntry::new(
+            "B-001",
+            "hello-bash",
+            "PMAT-261 fixture",
+            CorpusFormat::Bash,
+            CorpusTier::Trivial,
+            r#"fn main() { let greeting = "hello"; }"#,
+            "greeting='hello'",
+        ));
+        r
+    }
+
+    #[test]
+    fn test_PMAT261_cov_show_diff_needs_two_entries() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(&dir, &[line(1, 0.99, 0.0, 99, 100)]);
+        corpus_show_diff_with(&p, &CorpusOutputFormat::Human, None, None)
+            .expect_err("one entry cannot be diffed against anything");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_show_diff_human_and_json() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[line(1, 0.90, 0.0, 90, 100), line(2, 0.99, 0.09, 99, 100)],
+        );
+        corpus_show_diff_with(&p, &CorpusOutputFormat::Human, None, None)
+            .expect("two entries diff in human form");
+        corpus_show_diff_with(&p, &CorpusOutputFormat::Json, None, None).expect("and in json form");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_show_diff_explicit_iterations() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[
+                line(1, 0.90, 0.0, 90, 100),
+                line(2, 0.95, 0.05, 95, 100),
+                line(3, 0.99, 0.04, 99, 100),
+            ],
+        );
+        corpus_show_diff_with(&p, &CorpusOutputFormat::Human, Some(1), Some(3))
+            .expect("an explicit pair of iterations diffs");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_show_diff_unknown_iteration_is_an_error() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[line(1, 0.90, 0.0, 90, 100), line(2, 0.99, 0.09, 99, 100)],
+        );
+        corpus_show_diff_with(&p, &CorpusOutputFormat::Human, Some(1), Some(99))
+            .expect_err("an iteration that is not in the log cannot be diffed");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_generate_report_writes_to_a_temp_path() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(&dir, &[line(1, 0.99, 0.0, 99, 100)]);
+        let out = dir.path().join("report.md");
+        corpus_generate_report_with(
+            &tiny_registry(),
+            Some(out.to_str().expect("utf-8 path")),
+            &p,
+        )
+        .expect("a report over a one-entry registry writes");
+        let text = std::fs::read_to_string(&out).expect("report written");
+        assert!(
+            text.contains("V2 Corpus Quality Report"),
+            "the report carries its heading:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_PMAT261_cov_generate_report_to_stdout() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(&dir, &[line(1, 0.99, 0.0, 99, 100)]);
+        corpus_generate_report_with(&tiny_registry(), None, &p)
+            .expect("with no path the report prints");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_chrono_free_date_is_a_date_or_unknown() {
+        let d = chrono_free_date();
+        assert!(
+            d == "unknown" || (d.len() == 10 && d.matches('-').count() == 2),
+            "expected YYYY-MM-DD or unknown, got {d}"
+        );
+    }
+}

--- a/rash/src/cli/corpus_ops_commands.rs
+++ b/rash/src/cli/corpus_ops_commands.rs
@@ -244,3 +244,119 @@ pub(crate) fn corpus_benchmark(max_ms: u64, filter: Option<&CorpusFormatArg>) ->
     }
     Ok(())
 }
+
+// PMAT-261: coverage for the convergence check. Every path is a log written
+// into a TempDir, so no test depends on whichever `.quality/convergence.log`
+// the checkout happens to carry -- the defect PMAT-259 fixed.
+#[cfg(test)]
+mod pmat261_cov_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    /// One convergence-log line. `rate` and `delta` are fractions, as the
+    /// checks divide their percentage thresholds by 100.
+    fn line(iteration: u32, rate: f64, delta: f64, passed: usize, total: usize) -> String {
+        format!(
+            r#"{{"iteration":{iteration},"date":"2026-09-12","total":{total},"passed":{passed},"failed":{},"rate":{rate},"delta":{delta},"notes":"fixture"}}"#,
+            total - passed
+        )
+    }
+
+    fn log_with(dir: &TempDir, lines: &[String]) -> std::path::PathBuf {
+        let p = dir.path().join("convergence.log");
+        let mut f = std::fs::File::create(&p).expect("log created");
+        for l in lines {
+            writeln!(f, "{l}").expect("line written");
+        }
+        p
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_missing_log_is_an_error() {
+        let dir = TempDir::new().unwrap();
+        let err = corpus_converged_with_log(99.0, 0.5, 3, &dir.path().join("absent.log"))
+            .expect_err("a missing log cannot be converged");
+        assert!(matches!(err, Error::Internal(_)));
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_too_few_iterations_is_an_error() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(&dir, &[line(1, 0.99, 0.001, 99, 100)]);
+        corpus_converged_with_log(90.0, 1.0, 3, &p)
+            .expect_err("one iteration cannot satisfy a three-iteration window");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_all_checks_pass() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[
+                line(1, 0.99, 0.000, 99, 100),
+                line(2, 0.99, 0.001, 99, 100),
+                line(3, 0.99, 0.001, 99, 100),
+            ],
+        );
+        corpus_converged_with_log(90.0, 1.0, 3, &p)
+            .expect("a steady rate above the bar with no regression is converged");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_rate_below_threshold_fails() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[
+                line(1, 0.50, 0.000, 50, 100),
+                line(2, 0.50, 0.001, 50, 100),
+                line(3, 0.50, 0.001, 50, 100),
+            ],
+        );
+        corpus_converged_with_log(90.0, 1.0, 3, &p)
+            .expect_err("a rate under the threshold is not converged");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_large_delta_fails() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[
+                line(1, 0.99, 0.20, 99, 100),
+                line(2, 0.99, 0.20, 99, 100),
+                line(3, 0.99, 0.20, 99, 100),
+            ],
+        );
+        corpus_converged_with_log(90.0, 1.0, 3, &p)
+            .expect_err("a delta far above the bar is not stable");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_regression_between_iterations_fails() {
+        let dir = TempDir::new().unwrap();
+        let p = log_with(
+            &dir,
+            &[
+                line(1, 0.99, 0.000, 99, 100),
+                line(2, 0.99, 0.001, 99, 100),
+                line(3, 0.91, 0.001, 91, 100),
+            ],
+        );
+        corpus_converged_with_log(90.0, 1.0, 3, &p)
+            .expect_err("a drop in passing entries is a regression");
+    }
+
+    #[test]
+    fn test_PMAT261_cov_converged_print_check_both_branches() {
+        converged_print_check("a passing check", true);
+        converged_print_check("a failing check", false);
+    }
+
+    #[test]
+    fn test_PMAT261_cov_names_similar_matches_and_rejects() {
+        assert!(names_similar("cron-install-job", "cron-install-job"));
+        assert!(!names_similar("cron-install-job", "perl-extract-ip"));
+    }
+}


### PR DESCRIPTION
The v7.3.0 release gate measured **94.98 percent** line coverage, under the repository's 95 percent gate: PMAT-259 and PMAT-260 added lines that no test reached.

Fifteen tests across two files, all through the `_with` twins, so none reads the repository's own `.quality/convergence.log` or runs the full corpus. Every fixture is a log written into a `TempDir` and a one-entry registry.

- the convergence check from both sides: missing log, too few iterations, all checks passing, rate under the bar, delta over it, a regression between iterations, plus the two pure helpers
- the diff handler in human and json form, an explicit iteration pair, the unknown-iteration error
- the report handler to a path and to stdout, and the date helper

| check | before | after |
|---|---|---|
| line coverage | 94.98% | **95.06%** |
| `--fail-under-lines 95` | fails | exit 0 |
| new tests | — | 15, in 0.59s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)