### PR TITLE
docs(release): the v7.3.0 close-out (PMAT-262)

### DIFF
--- a/docs/audits/impl-PMAT-258-receipt.md
+++ b/docs/audits/impl-PMAT-258-receipt.md
@@ -68,3 +68,36 @@ Three lanes, three different models, none in the author's family (`gemini-3.1-pr
 - **Round 3** (gemini-3.1-pro-high, gemini-3.7-flash-high, gemini-3.8-flash-high): 2 PASS, 1 FAIL, and the FAIL was right. Contract F-LCX-020 named the module `tests_pmat258` in sc2106.rs, but that test sits in the file's existing `tests` module. pv gate 4 still passed, because it matches only the text after the last colon pair against bare test names, so the gate was green while the command written in the contract found nothing. Corrected, and every other test path in contracts/ was re-run individually to confirm it resolves to at least one test.
 
 That is the second time this release that a green gate hid a wrong claim, and both were caught by a reviewer rather than by the gate.
+
+## Released
+
+v7.3.0 shipped 2026-09-12 from merge commit 2312330960, with the required check green on it.
+
+| channel | verified |
+|---|---|
+| crates.io sparse index | `bashrs` and `bashrs-oracle` both at 7.3.0 |
+| GitHub release | v7.3.0 present, release workflow succeeded |
+| install | `cargo install bashrs --version 7.3.0` replaced 7.2.0 |
+| the breaking rename | `ps aux \| grep foo` reports SC2009, and not SC2106 |
+| the new rule | `( break )` inside a `for` loop reports SC2106 |
+| the new lowering | `s.len()` emits `n=${#s}` and the script prints 5 |
+
+Release gate before the tag: workspace tests pass, coverage **95.07 percent**, `pv lint contracts` PASS with gate 4 at 80 of 80, corpus **18,592 entries at 99.4/100 (A+)** under bwrap, book builds and its examples pass.
+
+## What the quorum caught, across four pull requests
+
+Every pull request in this release was reviewed by three lanes, each a named non-Claude model, before merge. Eleven rounds in total, and the refusals were worth their cost:
+
+| round | refusal | outcome |
+|---|---|---|
+| 1 | `Sandbox::new()` trusted bwrap's presence; an unusable bwrap exits 1 and every caller reads "not 124" as success, so every entry would pass without running | confirmed and fixed with a probe |
+| 3 | contract `F-LCX-020` named a module that does not exist; pv's gate matches only the final path segment, so the gate was green while the command found nothing | confirmed and fixed |
+| 5, 7 | a diff judged against the release ticket it was cut from | two tickets minted, PMAT-259 and PMAT-260 |
+| 9 | an unrelated lock bump in a scoped diff | the bump was out of scope there, and exposed that `main` could not publish at all |
+| 10 | `.pmat/baseline.json`, re-staged by the pre-commit hook, rode along in a commit | removed |
+
+Two of those are gates that were green while hiding a wrong claim. Both were caught by a reviewer, not by a gate.
+
+## Gaps carried to v7.4.0
+
+PMAT-253's remaining forjar-parity phases and PMAT-256, the runner's own sandbox rather than the release target's. Backlog: #233, #234, #236. `release-lint`'s treatment of cancelled entries is filed upstream as paiml/paiml-mcp-agent-toolkit#1326; the skill bundle was upgraded twice during this release and discarded the local patch each time.

--- a/docs/audits/impl-PMAT-262-receipt.md
+++ b/docs/audits/impl-PMAT-262-receipt.md
@@ -1,0 +1,15 @@
+# PMAT-262 receipt — the v7.3.0 close-out
+
+## What
+
+Ticket statuses for PMAT-258, 259, 260 and 261; the verified release record appended to the PMAT-258 receipt; the v7.3.0 sections dated in the plan and the notes; PMAT-253 and PMAT-256 moved to v7.4.0, because `release-lint` R3 refuses open work that names a release already cut; and the v7.4.0 sections opened in both documents.
+
+No code changes. `release-lint` is green: `open=2 releases=v7.4.0(2) highest_tag=v7.3.0`.
+
+## Why it is its own ticket
+
+Three quorum rounds refused close-out and follow-up diffs in this release because each was judged against the release ticket whose code had already merged. A lane compares the diff with its ticket's stated intent, and a documentation close-out does not implement a release. The rule held every time it was tested, so a close-out gets a ticket of its own from now on, opened at the start of the cycle rather than discovered at the end.
+
+## Release verification, recorded here rather than claimed
+
+The measurements behind the record are in `docs/audits/impl-PMAT-258-receipt.md` under "Released": the sparse index, the GitHub release, the install, and three behaviours checked against the installed 7.3.0 binary — SC2009 firing where SC2106 used to, SC2106 firing on a subshell break, and `s.len()` emitting `${#s}` and printing 5.

--- a/docs/audits/impl-PMAT-262-receipt.md
+++ b/docs/audits/impl-PMAT-262-receipt.md
@@ -4,7 +4,11 @@
 
 Ticket statuses for PMAT-258, 259, 260 and 261; the verified release record appended to the PMAT-258 receipt; the v7.3.0 sections dated in the plan and the notes; PMAT-253 and PMAT-256 moved to v7.4.0, because `release-lint` R3 refuses open work that names a release already cut; and the v7.4.0 sections opened in both documents.
 
-No code changes. `release-lint` is green: `open=2 releases=v7.4.0(2) highest_tag=v7.3.0`.
+No code changes. `release-lint` is green, measured after this ticket was itself added to the roadmap, which is what makes the count three rather than two:
+
+```
+release-lint: open=3 releases=v7.4.0(3) highest_tag=v7.3.0 plan=docs/roadmaps/releases.md notes=/home/noah/src/bashrs/docs/release-notes.md
+```
 
 ## Why it is its own ticket
 

--- a/docs/audits/impl-PMAT-262-receipt.md
+++ b/docs/audits/impl-PMAT-262-receipt.md
@@ -4,11 +4,14 @@
 
 Ticket statuses for PMAT-258, 259, 260 and 261; the verified release record appended to the PMAT-258 receipt; the v7.3.0 sections dated in the plan and the notes; PMAT-253 and PMAT-256 moved to v7.4.0, because `release-lint` R3 refuses open work that names a release already cut; and the v7.4.0 sections opened in both documents.
 
-No code changes. `release-lint` is green, measured after this ticket was itself added to the roadmap, which is what makes the count three rather than two:
+No code changes. `release-lint` reports, with this ticket itself counted, which is what makes the number three rather than two:
 
 ```
-release-lint: open=3 releases=v7.4.0(3) highest_tag=v7.3.0 plan=docs/roadmaps/releases.md notes=/home/noah/src/bashrs/docs/release-notes.md
+release-lint: open=3 releases=v7.4.0(3) highest_tag=v7.3.0
 ```
+
+**That green depends on a local patch.** The upstream `release-lint.sh` skips only `completed`, so it counts the three long-cancelled entries (PMAT-168, PMAT-169, PMAT-240) as open work that must each name a release, exits 1, and reports `open=6`. A blind quorum decided on 2026-09-11 that cancelled is closed, and the one-line change is filed upstream as paiml/paiml-mcp-agent-toolkit#1326; the skill bundle has been upgraded twice since and discarded the patch each time. A quorum lane measured exactly this difference from an unpatched environment, which is why it is written down here rather than left as an unqualified "green".
+
 
 ## Why it is its own ticket
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,9 +4,13 @@ One section per release. `release-lint` rule R5 reads the headings: every tag th
 
 Sections for releases before v7.1.0 carry the tag's own annotated message, which is the record that exists for them. From v7.1.0 the full notes live in `CHANGELOG.md` and the section here points at it.
 
+## v7.4.0
+
+In progress. Planned: the remaining forjar-parity phases (PMAT-253) and the corpus runner's own sandbox (PMAT-256).
+
 ## v7.3.0
 
-Tagged 2026-09-11.
+Tagged 2026-09-12.
 
 Three deferred decisions taken by blind quorum and implemented. **Breaking:** the rule bashrs called `SC2106` was shellcheck's `SC2009` and has moved there; `SC2106` now reports a `break` or `continue` inside a subshell. Change `# shellcheck disable=SC2106` to `SC2009` if you suppressed the ps-grep check.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,7 @@ Sections for releases before v7.1.0 carry the tag's own annotated message, which
 
 ## v7.4.0
 
-In progress. Planned: the remaining forjar-parity phases (PMAT-253) and the corpus runner's own sandbox (PMAT-256).
+In progress. Planned: the remaining forjar-parity phases (PMAT-253), the corpus runner's own sandbox (PMAT-256), and the v7.3.0 close-out (PMAT-262).
 
 ## v7.3.0
 

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -48,6 +48,7 @@ Goal: the forjar-parity phases that keep being carried, and the corpus runner's 
 |---|---|
 | PMAT-253 | forjar parity, the phases not shipped in v7.1.0 through v7.3.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b |
 | PMAT-256 | corpus runner sandbox: the runner itself, not only `make corpus-score` |
+| PMAT-262 | the v7.3.0 close-out: statuses, the verified release record, this plan |
 
 Issues on this release: none yet. Backlog: #233, #234, #236.
 

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -25,7 +25,7 @@ Issues on the GitHub milestone `v7.1.0`: #293, #294, #295, #265, #232.
 | PMAT-256 | corpus runner sandbox: temporary cwd, HOME and PATH everywhere, bwrap where Linux has it (make corpus-score sandboxes the release run; the runner itself is v7.3.0) |
 | PMAT-257 | the release itself: ten defects, pv gate 4 green, coverage 95.01 percent, the Pareto gates, the book |
 
-## v7.3.0
+## v7.3.0 (released 2026-09-12)
 
 Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rule that dogfooding keeps asking for, and the sandbox that stops a test writing into the repository. Coverage stays at or above 95 percent and every ticket carries a falsification test the contract verifier checks.
 
@@ -39,6 +39,17 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 | PMAT-261 | cover the convergence check, restoring coverage above the 95 percent gate |
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
+
+## v7.4.0
+
+Goal: the forjar-parity phases that keep being carried, and the corpus runner's own sandbox rather than the release target's. Coverage stays at or above 95 percent, every ticket carries a falsification test, and every pull request carries three independent quorum verdicts.
+
+| entry | what |
+|---|---|
+| PMAT-253 | forjar parity, the phases not shipped in v7.1.0 through v7.3.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b |
+| PMAT-256 | corpus runner sandbox: the runner itself, not only `make corpus-score` |
+
+Issues on this release: none yet. Backlog: #233, #234, #236.
 
 ## Unscheduled (blocked)
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2247,7 +2247,7 @@ roadmap:
   estimated_effort: null
   labels:
   - kind:code
-  - release:v7.3.0
+  - release:v7.4.0
   notes: 'orch-basis:operator — user wrote, verbatim: "in parallel ensure we are using a PR style and dogfood style like ../forjar (i.e. CRUX, quorum).  file ticket and research and then have "agy /teamwork review"". Filed during the PMAT-251 session (v7.0.4); research and the teamwork review are this session''s deliverable, implementation is scheduled with 7.1.0. | PMAT-254 (2026-09-10, v7.1.0 triage): release:v7.2.0 for phases 1a-1c, 2, 3b, 4a, 4b, 6, 7a, 7b; phases 3a and 5 ship in v7.1.0 under PMAT-255. orch:fable removed: model-gate refuses the ticket for every model because its basis token `operator` is not in the skill''s vocabulary; the default orchestrator (opus) runs it. | PMAT-255 (v7.1.0, 2026-09-11): shipped phase 3a''s gates D, G and K (gate B waits on the operator''s decision 4) and phase 5 (scripts/publish-from-tag.sh and the release.yml wait on the sparse index); the remaining phases stay release:v7.2.0.'
 - id: PMAT-254
   github_issue: null
@@ -2304,7 +2304,7 @@ roadmap:
   estimated_effort: null
   labels:
   - kind:code
-  - release:v7.3.0
+  - release:v7.4.0
   notes: 'Decided by quorum (2026-09-11, 2-1): the runner sandboxes itself and generation-time screening stays. Measured during the v7.1.0 cycle: 7 of 240 agent-generated candidate entries ran real commands, among them make builds, uv and agy, when executed with the callers environment. The dissenting lane warned that contributors without bwrap must still be able to run the corpus, which is why the cross-platform half of the decision is the temporary cwd, HOME and PATH. Record: docs/audits/quorum-decisions-v7.2.0.md'
 - id: PMAT-257
   github_issue: null
@@ -2328,7 +2328,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'v7.3.0: SC2106, the std-method lowerings behind the corpus removals, the corpus runner sandbox, deps, comply'
-  status: planned
+  status: completed
   priority: critical
   assigned_to: null
   created: 2026-09-11T17:29:55Z
@@ -2341,12 +2341,12 @@ roadmap:
   labels:
   - kind:code
   - release:v7.3.0
-  notes: null
+  notes: 'Shipped as v7.3.0 on 2026-09-12: SC2009 and the real SC2106, the len/to_string/unwrap_or lowerings, the corpus runner sandbox with a bwrap probe, 139 corpus entries, deps, and the book. Four pull requests each reviewed by three non-Claude quorum lanes before merge. Receipt: docs/audits/impl-PMAT-258-receipt.md'
 - id: PMAT-259
   github_issue: null
   item_type: task
   title: 'corpus_converged gains a _with_log twin, so a test does not depend on the checkout'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-11T21:01:12Z
@@ -2359,12 +2359,12 @@ roadmap:
   labels:
   - kind:code
   - release:v7.3.0
-  notes: null
+  notes: 'Shipped in v7.3.0: corpus_converged gained a _with_log twin so no test depends on the checkout. Receipt: docs/audits/impl-PMAT-259-receipt.md'
 - id: PMAT-260
   github_issue: null
   item_type: task
   title: regenerate Cargo.lock for 7.3.0 so --locked builds and the publish script work
-  status: planned
+  status: completed
   priority: critical
   assigned_to: null
   created: 2026-09-11T23:32:17Z
@@ -2377,12 +2377,12 @@ roadmap:
   labels:
   - kind:code
   - release:v7.3.0
-  notes: null
+  notes: 'Shipped in v7.3.0: the lockfile matched 7.2.0 while the manifest said 7.3.0, so cargo --locked failed and the publish script could not run. Receipt: docs/audits/impl-PMAT-260-receipt.md'
 - id: PMAT-261
   github_issue: null
   item_type: task
   title: cover the convergence check, restoring the 95 percent coverage gate
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-12T00:24:58Z
@@ -2395,4 +2395,4 @@ roadmap:
   labels:
   - kind:code
   - release:v7.3.0
-  notes: null
+  notes: 'Shipped in v7.3.0: coverage 94.98 to 95.07 percent, back above the gate. Receipt: docs/audits/impl-PMAT-261-receipt.md'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2396,3 +2396,21 @@ roadmap:
   - kind:code
   - release:v7.3.0
   notes: 'Shipped in v7.3.0: coverage 94.98 to 95.07 percent, back above the gate. Receipt: docs/audits/impl-PMAT-261-receipt.md'
+- id: PMAT-262
+  github_issue: null
+  item_type: task
+  title: 'v7.3.0 close-out: ticket statuses, the verified release record, and the v7.4.0 plan'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-12T01:31:20Z
+  updated: 2026-09-12T01:31:20Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - release:v7.4.0
+  notes: null


### PR DESCRIPTION
v7.3.0 is published and verified; this closes its tickets and opens the next release.

| channel | verified |
|---|---|
| crates.io sparse index | `bashrs` and `bashrs-oracle` both at 7.3.0 |
| GitHub release | v7.3.0 present, workflow succeeded |
| install | `cargo install bashrs --version 7.3.0` replaced 7.2.0 |
| the breaking rename | `ps aux \| grep foo` reports SC2009, not SC2106 |
| the new rule | `( break )` in a `for` loop reports SC2106 |
| the new lowering | `s.len()` emits `n=${#s}`; the script prints 5 |

Release gate before the tag: tests pass, coverage **95.07 percent**, `pv lint contracts` gate 4 at 80 of 80, corpus **18,592 entries at 99.4/100** under bwrap, book builds.

PMAT-258, 259, 260 and 261 close. PMAT-253 and PMAT-256 move to v7.4.0, because open work cannot name a release already cut, and the plan and notes gain their v7.4.0 sections.

The receipt records what eleven quorum rounds caught across four pull requests, including two gates that were green while hiding a wrong claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)