### PR TITLE
fix(linter): SC2242 counts case/loop nesting instead of flagging it (closes #331)

### DIFF
--- a/rash/src/linter/rules/sc2242.rs
+++ b/rash/src/linter/rules/sc2242.rs
@@ -1,4 +1,27 @@
-// SC2242: Can only exit from loops or functions, not case
+// SC2242: Can only break/continue from loops, not from a `case` outside one.
+//
+// Nesting is counted, NOT flagged. Three booleans cannot describe nesting:
+// an inner `done` cleared `in_loop` while the outer `while` was still open,
+// and a ONE-LINE `case … esac` never cleared `in_case` because the closer
+// test demanded the line BE `esac`. Together they made this shape a false
+// positive — valid bash, accepted by `bash -n`, reported as an error:
+//
+//     while IFS= read -r id; do
+//       case "$id" in '') continue ;; esac
+//       for a in 1 2; do
+//         for b in 3 4; do printf '%s%s\n' "$a" "$b"; done
+//       done
+//       if [ -z "$id" ]; then
+//         continue            # <- reported as "outside a loop"
+//       fi
+//     done < <(printf 'x\n')
+//
+// This is still a line/keyword heuristic, not a parser: it counts shell
+// KEYWORD TOKENS per line, so `case`/`esac` and `for`/`while`/`until`/`done`
+// opening and closing on one line balance correctly. A keyword inside a
+// quoted string or a heredoc is still miscounted; that needs the parser, and
+// the point of this change is that the counting is no longer wrong for code
+// anyone writes.
 use crate::linter::{Diagnostic, LintResult, Severity, Span};
 
 /// Check if line is a comment
@@ -6,30 +29,29 @@ fn is_comment_line(line: &str) -> bool {
     line.trim_start().starts_with('#')
 }
 
-/// Check if line starts a case statement
-fn is_case_start(line: &str) -> bool {
-    line.trim_start().starts_with("case ")
+/// Splits a line into shell-ish word tokens. `;`, `(`, `)`, `&`, `|` and
+/// backticks are separators, so `a) break ;; esac` yields `break` and
+/// `esac` as tokens of their own.
+fn tokens(line: &str) -> Vec<&str> {
+    line.split(|c: char| c.is_whitespace() || matches!(c, ';' | '(' | ')' | '&' | '|' | '`'))
+        .filter(|t| !t.is_empty())
+        .collect()
 }
 
-/// Check if line starts a loop
-fn is_loop_start(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    trimmed.starts_with("for ") || trimmed.starts_with("while ") || trimmed.starts_with("until ")
+/// How many times `keyword` appears as a WORD on this line.
+fn count_keyword(line: &str, keyword: &str) -> usize {
+    tokens(line).iter().filter(|t| **t == keyword).count()
+}
+
+/// Loop openers: `for`, `while`, `until`. `do` is not counted — it belongs
+/// to the opener that precedes it, and `done` is the single closer.
+fn count_loop_starts(line: &str) -> usize {
+    count_keyword(line, "for") + count_keyword(line, "while") + count_keyword(line, "until")
 }
 
 /// Check if line starts a function
 fn is_function_start(line: &str) -> bool {
     line.trim_start().contains("() {") || line.trim_start().starts_with("function ")
-}
-
-/// Check if line ends a case statement
-fn is_case_end(line: &str) -> bool {
-    line.trim_start() == "esac"
-}
-
-/// Check if line ends a loop
-fn is_loop_end(line: &str) -> bool {
-    line.trim_start() == "done"
 }
 
 /// Check if line ends a function
@@ -39,8 +61,9 @@ fn is_function_end(line: &str) -> bool {
 
 /// Check if line contains break or continue
 fn has_break_or_continue(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    trimmed.contains("break") || trimmed.contains("continue")
+    tokens(line)
+        .iter()
+        .any(|t| *t == "break" || *t == "continue")
 }
 
 /// Build diagnostic for invalid break/continue in case
@@ -55,9 +78,9 @@ fn build_diagnostic(line_num: usize, line_len: usize) -> Diagnostic {
 
 pub fn check(source: &str) -> LintResult {
     let mut result = LintResult::new();
-    let mut in_case = false;
-    let mut in_loop = false;
-    let mut in_function = false;
+    let mut case_depth: usize = 0;
+    let mut loop_depth: usize = 0;
+    let mut fn_depth: usize = 0;
 
     for (line_num, line) in source.lines().enumerate() {
         let line_num = line_num + 1;
@@ -66,30 +89,28 @@ pub fn check(source: &str) -> LintResult {
             continue;
         }
 
-        // Track context
-        if is_case_start(line) {
-            in_case = true;
-        }
-        if is_loop_start(line) {
-            in_loop = true;
-        }
+        let opened_case = count_keyword(line, "case");
+        let closed_case = count_keyword(line, "esac");
+        let opened_loop = count_loop_starts(line);
+        let closed_loop = count_keyword(line, "done");
+
+        // Openers count BEFORE the check so a `case … ) break ;; esac`
+        // written on one line is still judged inside its own case; closers
+        // count AFTER, so that same line's `esac` does not exempt it.
+        case_depth += opened_case;
+        loop_depth += opened_loop;
         if is_function_start(line) {
-            in_function = true;
-        }
-        if is_case_end(line) {
-            in_case = false;
-        }
-        if is_loop_end(line) {
-            in_loop = false;
-        }
-        if is_function_end(line) {
-            in_function = false;
+            fn_depth += 1;
         }
 
-        // Check for break/continue in case (when not in loop or function)
-        if in_case && !in_loop && !in_function && has_break_or_continue(line) {
-            let diagnostic = build_diagnostic(line_num, line.len());
-            result.add(diagnostic);
+        if case_depth > 0 && loop_depth == 0 && fn_depth == 0 && has_break_or_continue(line) {
+            result.add(build_diagnostic(line_num, line.len()));
+        }
+
+        case_depth = case_depth.saturating_sub(closed_case);
+        loop_depth = loop_depth.saturating_sub(closed_loop);
+        if is_function_end(line) {
+            fn_depth = fn_depth.saturating_sub(1);
         }
     }
     result
@@ -157,5 +178,79 @@ mod tests {
         let code = "case $var in\n  x) echo ok;;\nesac";
         let result = check(code);
         assert_eq!(result.diagnostics.len(), 0); // No break/continue
+    }
+}
+
+#[cfg(test)]
+mod nesting_tests {
+    use super::*;
+
+    /// The false positive this rule's counters were rewritten for: valid
+    /// bash that `bash -n` accepts and that runs, reported as an error.
+    /// Reverting `check` to the three booleans turns this red.
+    #[test]
+    fn a_continue_after_nested_loops_close_is_not_in_the_case() {
+        let code = "while IFS= read -r id; do\n\
+                    \x20 case \"$id\" in '') continue ;; esac\n\
+                    \x20 for a in 1 2; do\n\
+                    \x20   for b in 3 4; do\n\
+                    \x20     printf '%s%s\\n' \"$a\" \"$b\"\n\
+                    \x20   done\n\
+                    \x20 done\n\
+                    \x20 if [ -z \"$id\" ]; then\n\
+                    \x20   continue\n\
+                    \x20 fi\n\
+                    done < <(printf 'x\\n')";
+        let result = check(code);
+        assert_eq!(
+            result.diagnostics.len(),
+            0,
+            "{:?}",
+            result
+                .diagnostics
+                .iter()
+                .map(|d| d.span.start_line)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_one_line_case_closes_on_its_own_line() {
+        // Before: `is_case_end` demanded the line BE `esac`, so a one-line
+        // case stayed open for the rest of the file and every later
+        // break/continue outside a loop was flagged.
+        let code = "case $x in a) echo hi ;; esac\nbreak";
+        assert_eq!(check(code).diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn an_inner_done_does_not_close_the_outer_loop() {
+        let code = "for a in 1 2; do\n  for b in 3; do\n    echo x\n  done\n  break\ndone";
+        assert_eq!(check(code).diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn a_break_in_a_case_outside_any_loop_is_still_an_error() {
+        // The rule must still be capable of firing — the whole point.
+        let code = "case $x in\n  a) break ;;\nesac";
+        assert_eq!(check(code).diagnostics.len(), 1);
+        let one_line = "case $x in a) break ;; esac";
+        assert_eq!(check(one_line).diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn a_word_containing_a_keyword_is_not_the_keyword() {
+        // `donefile` / `casework` are not `done` / `case`.
+        let code = "case $x in\n  a) donefile=1; break ;;\nesac";
+        assert_eq!(check(code).diagnostics.len(), 1);
+        let code2 = "for f in casework; do\n  break\ndone";
+        assert_eq!(check(code2).diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn a_case_inside_a_loop_inside_a_case_still_resolves() {
+        let code = "case $x in\n  a)\n    for f in 1; do\n      case $f in 1) continue ;; esac\n    done\n    break ;;\nesac";
+        // The outer `break` is inside a case with NO enclosing loop.
+        assert_eq!(check(code).diagnostics.len(), 1);
     }
 }


### PR DESCRIPTION
Two defects in `rash/src/linter/rules/sc2242.rs`, one shape — a detector reporting a result it did not measure.

## Reproducer (14 lines; `bash -n` accepts it, and it runs)

```bash
#!/usr/bin/env bash
set -euo pipefail
while IFS= read -r id; do
  case "$id" in '') continue ;; esac
  for a in 1 2; do
    for b in 3 4; do
      printf '%s%s\n' "$a" "$b"
    done
  done
  if [ -z "$id" ]; then
    continue                    # <- reported as "outside a loop"
  fi
  printf '%s\n' "$id"
done < <(printf 'x\n')
```

```
✗ 11:1-13 [error] SC2242: Can only break/continue from loops. Use 'exit' to exit case or function
```

## Root cause

`check()` tracks context with `in_case` / `in_loop` / `in_function` as **booleans, not depth counters**:

1. **An inner `done` closes the outer loop.** `for`/`for` set `in_loop = true` (already true), then each
   of the two `done` lines sets `in_loop = false` — so after the nested loops close, the still-open
   `while` is invisible.
2. **A one-line `case … esac` never closes.** `is_case_end` is `line.trim_start() == "esac"`, which is
   false for a `case … ;; esac` written on one line, so `in_case` stays true for the rest of the file.

Either alone is survivable; together they make `in_case && !in_loop` true inside a loop, and every later
`break`/`continue` is flagged. Found while linting a done_when script in `paiml/infra` (PMAT-534): the
rule reported 2 errors on a script `bash -n` accepts and that runs correctly.

## Fix

`fix/sc2242-nesting-depth`: keyword-TOKEN depth counters (`;`, `(`, `)`, `&`, `|` and backtick are
separators, so a `break ;; esac` clause yields `break` and `esac` as their own tokens); openers count
before the check and closers after, so a one-line case whose clause breaks is still judged inside its own
case while a one-line `for … done` balances. Still a line/keyword heuristic, not a parser — a keyword
inside a quoted string or a heredoc is still miscounted, and the code says so — but it is no longer wrong
for code anyone writes.

Six tests added, including the reproducer above, `donefile`/`casework` (a word containing a keyword is
not the keyword) and a case-in-loop-in-case nesting. **Discrimination proven**: reverting `check()` to
the boolean behaviour turns exactly the two new nesting tests RED
(`a_continue_after_nested_loops_close_is_not_in_the_case`, `a_one_line_case_closes_on_its_own_line`) and
leaves the other 14 green. The rule still fires on the real defect: a `break` in a case outside any loop
is still one error, whether the case is written on one line or three.

---

## Verification

- `cargo test -p bashrs --lib linter::` — **6067 passed, 0 failed**
- `cargo clippy -p bashrs --lib -- -D warnings` — clean
- `cargo fmt --check` — clean
- The **built binary** (not the claim about it) gives **0 errors** on the script that started this, and the 14-line reproducer lints clean.
- **Discrimination proven**: reverting `check()` to the boolean behaviour turns exactly the two new nesting tests red — `a_continue_after_nested_loops_close_is_not_in_the_case` and `a_one_line_case_closes_on_its_own_line` — and leaves the other 14 green.

Found while landing `paiml/infra` PMAT-534, where these were 2 of the 6 `bashrs lint` errors on a done_when script. The other 4 were real findings and were fixed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)