### PR TITLE
docs(release): the v7.4.0 close-out — verified on every channel, #233 closed, #236 re-measured, v7.5.0 planned (PMAT-264)

### DIFF
--- a/docs/audits/impl-PMAT-264-receipt.md
+++ b/docs/audits/impl-PMAT-264-receipt.md
@@ -1,0 +1,72 @@
+# PMAT-264 receipt — the v7.4.0 close-out
+
+## Identity
+
+| field | value |
+|---|---|
+| ticket | PMAT-264, kind=code, `release:v7.4.0` |
+| branch | PMAT-264-v7.4.0-closeout, from main at 4aa24ca271 |
+| tag | v7.4.0 on 4aa24ca271, annotated |
+| gate_cmd | `make release-gate` |
+| required_check | `gate` |
+| author model | claude-opus-5 |
+
+orch_model: opus-5 [V]   orch_class: opus   orch_decision: admit   orch_basis: file
+fable_binding: false   quota_age_h: absent   quota_mark: -   k_measured_at_set: refused (one ticket per session; PMAT-248 holds the goal file)
+
+routes:
+  ph1  class=measurement    route=self  w=100.00  basis=absent   re-measure #236 and #233 against the released binary
+  ph2  class=orchestration  route=self  w=100.00  basis=absent   tag, publish, verify, statuses, the v7.5.0 plan
+
+verification:
+  cmd="make release-gate"  claimed_exit=0  rerun_exit=0  log_path=/home/noah/.cache/paiml-implement/logs/PMAT-264/release-gate.log  sha256=cf69d83eba36
+  cmd="scripts/publish-from-tag.sh v7.4.0"  claimed_exit=0  rerun_exit=0  log_path=/home/noah/.cache/paiml-implement/logs/PMAT-264/publish.log  sha256=8379224d796f
+  cmd="cargo install bashrs --version 7.4.0 --locked"  claimed_exit=0  rerun_exit=0  log_path=/home/noah/.cache/paiml-implement/logs/PMAT-264/install.log  sha256=458ae34ae65e
+
+## The release, as measured rather than assumed
+
+`make release-gate` was run twice. The first run is **discarded**: it started on `main` in the shared checkout, and while it ran that checkout moved to another branch carrying an unrelated linter change (1c533e042f, #331), so the tree it measured was not the tree being tagged. The second run is the record: a detached worktree at 4aa24ca271, nothing else in it.
+
+| check | result |
+|---|---|
+| `make release-gate` (clean worktree at 4aa24ca271) | **green**, exit 0 |
+| workspace tests | 15,693 passed, 0 failed, 68 ignored (62.95s) |
+| coverage | **95.08 percent** lines (regions 94.67, functions 95.63), `--fail-under-lines 95` exit 0 |
+| gate S | GATE S PASS, 89 files checked, 89 at ratchet, 0 improved, 94 errors |
+| `pv lint contracts` | PASS, 0 errors; gate 4 at 86 refs, 86 found, 0 missing |
+| corpus, under bwrap | **18,814 entries, 18,814 passed, 0 failed, 99.4/100 (A+)**; bash 99.4 (16,970), makefile 98.6 (1,049), dockerfile 100.0 (795) |
+| book | builds, examples pass |
+| required check on the merge commit | `gate` green on 4aa24ca271 (run 34686584716) |
+| tag | `v7.4.0` annotated on 4aa24ca271, pushed |
+| crates.io | bashrs-oracle 7.4.0 then bashrs 7.4.0 published by `scripts/publish-from-tag.sh` (dry run first, exit 0 both times) |
+| release.yml | completed success (run 34688384966); GitHub release v7.4.0 published, not a draft |
+| installed binary | `cargo install bashrs --version 7.4.0 --locked` → `bashrs 7.4.0`; `bashrs corpus summary` from a fresh directory reports **18,814 entries, 99.4/100 A+** |
+
+## #233, closed with its own measurement
+
+Both halves. The clippy-scoping half shipped in this release (PMAT-263); the "37 of 145 targets do not compile" half was fixed in v6.67.0 and re-measured at **0** compile errors. What the re-measurement exposed is that the required check runs `--lib`, so those targets ran nowhere in CI — the nightly full gate is the answer, and the issue comment says so. Closed, labelled `release:7.4.0`.
+
+## #236, re-measured and re-scheduled
+
+bashrs 7.4.0 against shellcheck 0.8.0 over the same repository (`docs/audits/sc-vs-shellcheck-v7.4.0.md`, logs `/home/noah/.cache/paiml-implement/logs/PMAT-264/i236-*.log`). SC2046 is **72 vs 5**, not the issue's 210:1; five of the thirteen codes it named are now **zero**. It stays open because SC2086 (316 vs 7), SC2154 (108 vs 0) and SC1004 (92 vs 0) still carry non-shellcheck meanings, each with a measured example in the audit. Retagged `release:7.5.0`.
+
+## Statuses and the v7.5.0 plan
+
+| entry | status | why |
+|---|---|---|
+| PMAT-263 | completed | the release shipped and is verified above |
+| PMAT-265 | completed | merged in #330; six falsification tests, 19 corpus entries |
+| PMAT-256 | completed | all three criteria shipped in v7.3.0 under PMAT-258; the third was measured at the v7.4.0 gate — the corpus scores identically inside and outside bwrap, byte for byte, and `.quality/last-corpus-run.json` is written to the caller's directory |
+| PMAT-264 | completed | this diff |
+| PMAT-253 | moved to `release:v7.5.0` | phases 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b unchanged; decision D4 (gate S) shipped in v7.4.0 |
+
+Every open issue names a release: #236 and #331 and #234 are all `release:7.5.0`; the backlog is empty. `release-lint` is green (R1–R5) with one open entry, PMAT-253, against a described v7.5.0.
+
+## Gaps
+
+- `release-lint`'s R1 treats a `cancelled` roadmap entry as open work; the local patch that fixes it is discarded on every skill upgrade and had to be re-applied twice in this cycle. Filed upstream as paiml-mcp-agent-toolkit#1326, still open.
+- The shared checkout moved branches mid-gate. Release measurement now runs in its own detached worktree; the receipt says which run it kept and why.
+
+verdict: PASS — v7.4.0 is tagged, published, installed and verified from the index; every ticket on it is closed with evidence; every open issue names a release; v7.5.0 is described in both the plan and the notes.
+
+IMPL-PMAT-264-RECEIPT-END

--- a/docs/audits/sc-vs-shellcheck-v7.4.0.md
+++ b/docs/audits/sc-vs-shellcheck-v7.4.0.md
@@ -1,0 +1,81 @@
+# bashrs 7.4.0 against shellcheck 0.8.0, on the sample issue #236 measured
+
+Re-measurement for the v7.4.0 close-out (PMAT-264). Issue #236 measured bashrs
+6.67.0 against shellcheck 0.8.0 over the tracked `*.sh` files of
+`paiml/paiml-mcp-agent-toolkit` and reported `SC2046` at 210:1. This is the same
+comparison with the released 7.4.0 binary, run 2026-09-12.
+
+## Method
+
+```
+bashrs 7.4.0 (release build of 4aa24ca271)   shellcheck 0.8.0
+for f in $(git ls-files '*.sh'); do
+  bashrs lint --format json "$f" | jq '.diagnostics[]?'      # 97 files
+  shellcheck -f json1 "$f"      | jq '.comments[]?'
+done
+```
+
+**The file set is not the issue's.** The issue counted 40 tracked `*.sh`; the
+repository now tracks 97, so the absolute counts are not comparable with the
+issue's table and only the per-code shape is. shellcheck reports 130
+diagnostics in total over these 97 files.
+
+## Per code, the codes the issue named
+
+| code | bashrs 6.67.0 (40 files) | bashrs 7.4.0 (97 files) | shellcheck 0.8.0 (97 files) |
+|---|---|---|---|
+| SC2046 | 210 | **72** | 5 |
+| SC2086 | 97 | **316** | 7 |
+| SC1004 | 75 | **92** | 0 |
+| SC1078 | 40 | **0** | 0 |
+| SC2183 | 27 | **0** | 0 |
+| SC2047 | 23 | **20** | 0 |
+| SC1009 | 21 | **0** | 0 |
+| SC2164 | 21 | **26** | 0 |
+| SC1028 | 19 | **0** | 0 |
+| SC2161 | 18 | **19** | 0 |
+| SC2036 | 10 | **0** | 0 |
+| SC2101 | 10 | **14** | 0 |
+| SC2154 | 10 | **108** | 0 |
+
+Five of the thirteen codes the issue named are now **zero**: SC1078, SC1009,
+SC1028, SC2036 and SC2183. Those are the lexer-context class fixed across
+v7.1.0–v7.3.0 (PMAT-248, PMAT-250, PMAT-255, PMAT-257).
+
+## What is left, largest first, with a measured example each
+
+1. **SC2086 inside a heredoc body** — 316 reports. A heredoc body is data, not
+   code; `$TIMESTAMP` inside one is not a word the shell splits at that point.
+   Reproducer (bashrs reports SC2086 at line 4, shellcheck reports nothing):
+   ```sh
+   #!/bin/sh
+   TIMESTAMP=x
+   cat <<EOF
+   **Time**: $TIMESTAMP
+   EOF
+   ```
+   This is GH-242's class (a heredoc body reaching a shell rule) for a rule
+   that was not in that ticket's list.
+
+2. **SC2154 on a variable a sourced file defines** — 108 reports.
+   `lsb_dist="$(. /etc/os-release && echo "$ID")"` draws SC2154 ("referenced
+   but not assigned") where shellcheck reports SC1091 ("not following") and
+   nothing else: it knows a sourced file may define the name.
+   (`get-docker.sh:263`, and 4 more in that file.)
+
+3. **SC1004 across a multi-line quoted argument** — 92 reports, 75 of them in
+   one file (`scripts/create-doc-validate-issues.sh`), where a `gh issue
+   create` call carries a multi-line `--body` containing escaped backticks.
+   Reduced reproducers of the individual constructs (an escaped backtick in a
+   double-quoted string, a backslash-continued pipeline, a multi-line quoted
+   argument) each draw **no** SC1004, so the trigger is a combination and the
+   reduction is the first job of the ticket that fixes it.
+
+## Verdict
+
+#236's headline claim is no longer true as written: SC2046 is 14:1, not 210:1.
+The issue stays open because its subject — "bashrs reuses shellcheck's numbering
+so users expect comparable semantics" — is still unsatisfied for SC2086,
+SC2154 and SC1004, which are now the three largest gaps. The issue is retagged
+`release:v7.5.0` with this measurement, and the three classes above are its
+work items.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,11 +4,17 @@ One section per release. `release-lint` rule R5 reads the headings: every tag th
 
 Sections for releases before v7.1.0 carry the tag's own annotated message, which is the record that exists for them. From v7.1.0 the full notes live in `CHANGELOG.md` and the section here points at it.
 
+## v7.5.0
+
+Planned. The forjar-parity phases that keep being carried (PMAT-253: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b) and issue #236, re-measured at the v7.4.0 close-out: SC2046 is now 14:1 against shellcheck rather than 210:1, and the three largest remaining gaps are SC2086 inside a heredoc body, SC2154 on a variable a sourced file defines, and SC1004 across a multi-line quoted argument (`docs/audits/sc-vs-shellcheck-v7.4.0.md`).
+
 ## v7.4.0
 
-In progress; the release ticket is PMAT-263, the close-out PMAT-264.
+Tagged 2026-09-12, published to crates.io, verified with `cargo install bashrs --version 7.4.0`.
 
-The required check lints the whole workspace (#233): `ci / lint` and `make release-gate` both ran a clippy scoped to the root stub package, and now name the workspace. The self-lint is gate S, with a per-file ratchet (`make dogfood-selflint`, PMAT-253 decision D4). A nightly workflow runs `cargo test --workspace`, the targets the required check skips. 203 corpus entries (18,592 to 18,795) and a corpus release bar that ratchets to the last shipped count. Two transpiler defects the new entries exposed are filed as PMAT-265.
+The required check lints the whole workspace (#233): `ci / lint` and `make release-gate` both ran a clippy scoped to the root stub package, and now name the workspace; making the tree clean under it took six kinds of fix, including an orphan test fragment in bashrs-wasm whose tests had never compiled. A nightly workflow runs `cargo test --workspace` — the integration targets, doctests and examples the required check skips. The self-lint is gate S, with a per-file ratchet (`make dogfood-selflint`, PMAT-253 decision D4). `std::env::var` is an environment read again rather than a command substitution of a command that does not exist, its Result methods have exact POSIX spellings, an `unwrap_or` default is spelled for the expansion it sits in, and arithmetic inside a `capture()` string is no longer read as command substitution (PMAT-265). 222 corpus entries (18,592 to 18,814) and a release bar that ratchets to the last shipped count.
+
+Measured at the gate: 15,693 library tests, coverage 95.08 percent, corpus 18,814 entries at 99.4/100 (A+) with 0 failures, GATE S PASS, `pv lint contracts` gate 4 at 86 of 86.
 
 Full notes: the `[7.4.0]` section of `CHANGELOG.md`.
 

--- a/docs/roadmaps/releases.md
+++ b/docs/roadmaps/releases.md
@@ -39,7 +39,17 @@ Goal: the lowerings the v7.2.0 corpus removals exposed, the loop-containment rul
 
 Issues on this release: #303 (SC2106 not implemented), #316 (53 corpus entries exercised std methods with no lowering), #318 (an untracked copy of the source tree written by a test).
 
-## v7.4.0
+## v7.5.0
+
+Goal: the forjar-parity phases that have been carried since v7.1.0, and the shellcheck-parity gaps #236 still names after v7.4.0 re-measured it. Coverage stays at or above 95 percent, every ticket carries a falsification test, and every pull request carries three independent quorum verdicts.
+
+| entry | what |
+|---|---|
+| PMAT-253 | forjar parity, the phases not shipped in v7.1.0 through v7.4.0: 1a–1c, 2, 3b, 4a, 4b, 6, 7a, 7b (decision D4, gate S, shipped in v7.4.0) |
+
+Issues on this release: #236 (SC2086 in a heredoc body, SC2154 on a sourced variable, SC1004 across a multi-line quoted argument — measured in `docs/audits/sc-vs-shellcheck-v7.4.0.md`), #331 (SC2242 reads nested loops through three booleans and never closes a one-line `case … esac`), #234 (the TDG grade gate: 120 functions below grade A). Backlog: none — every open issue names a release.
+
+## v7.4.0 (released 2026-09-12)
 
 Goal: the forjar-parity phases that keep being carried, and the corpus runner's own sandbox rather than the release target's. Coverage stays at or above 95 percent, every ticket carries a falsification test, and every pull request carries three independent quorum verdicts.
 
@@ -51,7 +61,9 @@ Goal: the forjar-parity phases that keep being carried, and the corpus runner's 
 | PMAT-265 | `std::env::var` is an environment read; its Result methods, a default spelled for the expansion it sits in, arithmetic in `capture()` — found by validating the release's own corpus candidates |
 | PMAT-264 | the close-out: statuses, the verified release record, the v7.5.0 plan |
 
-Issues on this release: #233 (CI lints only the bashrs-specs stub). Backlog: #234, #236.
+Issues on this release: #233 (CI lints only the bashrs-specs stub) — the clippy-scoping half closed here; the integration-target half was closed in v6.67.0 and re-measured at 0 errors. Backlog: #234.
+
+Released: tag `v7.4.0` on 4aa24ca271, `bashrs 7.4.0` on crates.io, `cargo install bashrs --version 7.4.0` verified (reports `bashrs 7.4.0`, corpus 18,814 entries at 99.4/100 A+).
 
 ## Unscheduled (blocked)
 

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2247,7 +2247,7 @@ roadmap:
   estimated_effort: null
   labels:
   - kind:code
-  - release:v7.4.0
+  - release:v7.5.0
   notes: 'orch-basis:operator — user wrote, verbatim: "in parallel ensure we are using a PR style and dogfood style like ../forjar (i.e. CRUX, quorum).  file ticket and research and then have "agy /teamwork review"". Filed during the PMAT-251 session (v7.0.4); research and the teamwork review are this session''s deliverable, implementation is scheduled with 7.1.0. | PMAT-254 (2026-09-10, v7.1.0 triage): release:v7.2.0 for phases 1a-1c, 2, 3b, 4a, 4b, 6, 7a, 7b; phases 3a and 5 ship in v7.1.0 under PMAT-255. orch:fable removed: model-gate refuses the ticket for every model because its basis token `operator` is not in the skill''s vocabulary; the default orchestrator (opus) runs it. | PMAT-255 (v7.1.0, 2026-09-11): shipped phase 3a''s gates D, G and K (gate B waits on the operator''s decision 4) and phase 5 (scripts/publish-from-tag.sh and the release.yml wait on the sparse index); the remaining phases stay release:v7.2.0.'
 - id: PMAT-254
   github_issue: null
@@ -2289,7 +2289,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'corpus runner sandbox: every entry runs in a temporary cwd, HOME and PATH, and under bwrap where Linux has it'
-  status: planned
+  status: completed
   priority: high
   assigned_to: noahgift
   created: 2026-09-11T08:30:00Z
@@ -2418,7 +2418,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'v7.4.0: the required check runs what it claims (#233), the per-file self-lint ratchet, deps, corpus growth'
-  status: planned
+  status: completed
   priority: critical
   assigned_to: null
   created: 2026-09-12T06:21:46Z
@@ -2436,7 +2436,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'v7.4.0 close-out: statuses, the verified release record, the v7.5.0 plan'
-  status: planned
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-09-12T06:21:46Z
@@ -2454,7 +2454,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'std::env::var lowering: bare read, unwrap_or, unwrap_or_else, unwrap_or_default, unwrap, expect; a quoted default that survives every shell; arithmetic in capture() strings'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-12T07:43:36Z


### PR DESCRIPTION
## PMAT-264 — the v7.4.0 close-out

Receipt: `docs/audits/impl-PMAT-264-receipt.md`. Audit: `docs/audits/sc-vs-shellcheck-v7.4.0.md`.

### The release, verified rather than assumed
- Tag `v7.4.0` on 4aa24ca271; `gate` green on that merge commit.
- `make release-gate` **green** in a detached worktree of the tag: 15,693 workspace tests, coverage **95.08 %**, GATE S PASS (89 files, 94 errors, 0 over), `pv lint contracts` gate 4 at 86/86, corpus **18,814 entries at 99.4/100 (A+)** with 0 failures, book builds.
- The first release-gate run is **discarded and the receipt says why**: it started on `main` in the shared checkout, and that checkout moved to another branch mid-run (an unrelated linter change), so it did not measure the tree being tagged.
- Published through `scripts/publish-from-tag.sh` (dry run first): bashrs-oracle 7.4.0, then bashrs 7.4.0. `release.yml` success; GitHub release published.
- `cargo install bashrs --version 7.4.0 --locked` → `bashrs 7.4.0`; that binary's `corpus summary` from a fresh directory reports 18,814 entries at 99.4/100 A+, matching the gate.

### #233 — closed, both halves measured
Clippy scoping shipped in this release; the "37 of 145 targets do not compile" half was fixed in v6.67.0 and re-measured at **0** errors. What that exposed — the required check runs `--lib`, so those targets ran nowhere in CI — is what the new nightly full gate answers. Comment on the issue carries the detail.

### #236 — re-measured, not argued
bashrs 7.4.0 vs shellcheck 0.8.0, same repository: SC2046 is **72 vs 5**, not 210:1, and five of the thirteen codes the issue named are now **zero**. It stays open for the three classes that remain, each with a reproducer: SC2086 in a heredoc body (316 vs 7), SC2154 on a variable a sourced file defines (108 vs 0), SC1004 across a multi-line quoted argument (92 vs 0). Retagged `release:7.5.0`.

### Statuses and the plan
PMAT-263, PMAT-265, PMAT-256 and PMAT-264 completed (PMAT-256's third criterion measured at this gate: the corpus scores identically inside and outside bwrap). PMAT-253 moves to v7.5.0 with its unshipped phases named. Every open issue names a release (#236, #331, #234 → 7.5.0); the backlog is empty. `release-lint` R1–R5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
